### PR TITLE
Fixed DB3 when left out subject is 11

### DIFF
--- a/Model/Model_Trainer.py
+++ b/Model/Model_Trainer.py
@@ -248,7 +248,6 @@ class Model_Trainer():
                 pin_memory=True
             )
             
-            
             self.val_loader = DataLoader(
                 val_dataset, 
                 batch_size=self.batch_size, 
@@ -284,6 +283,10 @@ class Model_Trainer():
         if self.args.turn_on_rms:
             wandb_runname += '_rms-'+str(self.args.rms_input_windowsize)
         if self.args.leftout_subject != 0:
+            if (self.args.force_regression and self.args.dataset == "ninapro-db3") and self.args.leftout_subject == 10:
+                # Subject 10 in DB3 is missing a lot of data. We delete it internally and subject 11 gets shifted to become subject 10. Naming it its the "external" subject number for consistency. 
+                wandb_runname += '_LOSO-11'
+
             wandb_runname += '_LOSO-'+str(self.args.leftout_subject)
         wandb_runname += '_' + self.model_name
         if (self.exercises and not self.args.partial_dataset_ninapro):
@@ -332,7 +335,7 @@ class Model_Trainer():
         if self.args.proportion_unlabeled_data_from_training_subjects>0:
             wandb_runname += '_unlabel-subj-prop-' + str(self.args.proportion_unlabeled_data_from_training_subjects)
 
-        if self.args.target_normalize_subject != self.args.leftout_subject:
+        if (self.args.target_normalize > 0) and (self.args.target_normalize_subject != self.args.leftout_subject):
             wandb_runname += '_targ-norm-subj-' + str(self.args.target_normalize_subject)
 
         self.wandb_runname = wandb_runname

--- a/Setup/Setup.py
+++ b/Setup/Setup.py
@@ -158,17 +158,12 @@ class Setup():
         self.exercises = False
         self.args.dataset = self.args.dataset.lower()
 
-        if self.args.target_normalize_subject == 0:
-            self.args.target_normalize_subject = self.args.leftout_subject
-            print("Target normalize subject defaulting to leftout subject.")
-
         if self.args.model == "MLP" or self.args.model == "SVC" or self.args.model == "RF":
             print("Warning: not using pytorch, many arguments will be ignored")
             if self.args.turn_on_unlabeled_domain_adaptation:
                 raise NotImplementedError("Cannot use unlabeled domain adaptation with MLP, SVC, or RF")
             if self.args.pretrain_and_finetune:
                 raise NotImplementedError("Cannot use pretrain and finetune with MLP, SVC, or RF")
-
 
         if (self.args.dataset in {"uciemg", "uci"}):
             if (not os.path.exists("./uciEMG")):
@@ -222,8 +217,8 @@ class Setup():
             assert not(self.args.force_regression and self.args.leftout_subject == 10), "Subject 10 is missing gesture data for exercise 3 and cannot be used. Please choose another subject."
 
             if self.args.force_regression and self.args.leftout_subject == 11: 
-                self.args.leftout_subject = 10
                 # subject 10 is missing force data and is deleted internally 
+                self.args.leftout_subject = 10
 
             self.args.dataset = 'ninapro-db3'
 
@@ -307,6 +302,10 @@ class Setup():
             assert self.args.dataset in {"ninapro-db2", "ninapro-db3"}, "Regression only implemented for Ninapro DB2 and DB3 dataset." 
             assert not self.args.partial_dataset_ninapro, "Cannot use partial dataset for regression. Set exercises=3." 
 
+        if (self.args.target_normalize > 0) and self.args.target_normalize_subject == 0:
+            self.args.target_normalize_subject = self.args.leftout_subject
+            print("Target normalize subject defaulting to leftout subject.")
+
         # Add date and time to filename
         current_datetime = datetime.datetime.now()
         self.formatted_datetime = current_datetime.strftime("%Y-%m-%d_%H-%M-%S")
@@ -319,10 +318,16 @@ class Setup():
 
         
 
+        
+
     def print_params(self):
         for param, value in vars(self.args).items():
             if getattr(self.args, param):
-                print(f"The value of --{param} is {value}")
+                if param == "target_normalize_subject":
+                    if self.args.target_normalize != 0.0:
+                        print(f"The value of --{param} is {value}")
+                else:
+                    print(f"The value of --{param} is {value}")
 
     def set_exercise(self):
         """ Set the self.exercises for the partial dataset for Ninapro datasets. 


### PR DESCRIPTION
Made it so that target_norm_subject is only used/updated when target_norm > 0. 
Updated LOSO value to always be 11 externally (wandb_runname) when DB3, force regression, and LOSO=11.