### PR TITLE
Include transition windows

### DIFF
--- a/Data/Combined_Data.py
+++ b/Data/Combined_Data.py
@@ -96,7 +96,12 @@ class Combined_Data():
 
                 if self.args.force_regression:
                     assert(exercise == 3), "Regression only implemented for exercise 3"
-                    forces_async = pool.map_async(self.utils.getForces, list(zip([(i+1) for i in range(self.utils.num_subjects)], exercise*np.ones(self.utils.num_subjects).astype(int))))
+                    forces_async = pool.map_async(self.utils.getForces, list(
+                        
+                        zip(
+                            [(i+1) for i in range(self.utils.num_subjects)], exercise*np.ones(self.utils.num_subjects).astype(int), 
+                            [self.args]*np.ones(self.utils.num_subjects).astype(int)
+                    )))
                     forces.append(forces_async.get())
                     
                 assert len(emg[-1]) == len(labels[-1]), "Number of trials for EMG and labels do not match"

--- a/Data/Combined_Data.py
+++ b/Data/Combined_Data.py
@@ -97,7 +97,6 @@ class Combined_Data():
                 if self.args.force_regression:
                     assert(exercise == 3), "Regression only implemented for exercise 3"
                     forces_async = pool.map_async(self.utils.getForces, list(
-                        
                         zip(
                             [(i+1) for i in range(self.utils.num_subjects)], exercise*np.ones(self.utils.num_subjects).astype(int), 
                             [self.args]*np.ones(self.utils.num_subjects).astype(int)

--- a/Data/Combined_Data.py
+++ b/Data/Combined_Data.py
@@ -115,6 +115,9 @@ class Combined_Data():
             self.Y.data = labels
         self.label.data = labels
 
+        for i in range(len(self.X.data[0])):
+            assert(len(self.X.data[0][i]) == len(self.Y.data[0][i])), "Number of windows for X and Y do not match."
+
     def load_other_datasets(self):
 
         emg = []

--- a/Data/X_Data.py
+++ b/Data/X_Data.py
@@ -96,7 +96,8 @@ class X_Data(Data):
             else:
                 exercises_numbers_filename = '-'.join(map(str, self.args.exercises))
                 base_foldername_zarr += f'exercises{exercises_numbers_filename}/'
-            
+        if self.args.include_transitions: 
+            base_foldername_zarr += 'include_transitions/'
         if self.args.save_images: 
             if not os.path.exists(base_foldername_zarr):
                 os.makedirs(base_foldername_zarr)

--- a/Data/X_Data.py
+++ b/Data/X_Data.py
@@ -116,6 +116,7 @@ class X_Data(Data):
 
         emg = self.data # should already be defined as emg using load_data
         image_data = []
+        # emg[0].shape = 796 -> has the extra windows
         for x in tqdm(range(len(emg)), desc="Number of Subjects "):
             if self.args.leave_one_session_out:
                 subject_folder = f'session{x}/'
@@ -162,6 +163,8 @@ class X_Data(Data):
                 else:
                     print(f"Did not save dataset for subject {x} at {foldername_zarr} because save_images is set to False")
                 image_data += [images]
+
+            assert len(emg[x]) == len(image_data[x]), f"Number of windows in EMG and images do not match when x = {x}. Deleting old images may fix this issue."
                 
-        self.data = image_data
+        self.data = image_data 
         

--- a/Model/Model_Trainer.py
+++ b/Model/Model_Trainer.py
@@ -338,6 +338,9 @@ class Model_Trainer():
         if self.args.target_normalize_subject != self.args.leftout_subject:
             wandb_runname += '_targ-norm-subj-' + str(self.args.target_normalize_subject)
 
+        if self.args.include_transitions: 
+            wandb_runname += '_include-transitions'
+
         self.wandb_runname = wandb_runname
 
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ New datasets can be benchmarked with `CNN_EMG.py` after being processed into HDF
 
 To run the new dataset, input the dataset name to the dataset argument of `CNN_EMG.py`. Every subject must have data for all of the gestures in order for the dataset to be processed by `utils_generic.py`.
 
-NOTE: Images should be deleted when utils are updated. 
+NOTE: Saved images should be deleted any time utils are updated. Any additional arguments should be added to create_foldername_zarr() and set_wandb_runname().
 
 ## Creating Custom Runs
 run_CNN_EMG.py also takes in config files. Create a new yaml file with your arguments and run: 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ New datasets can be benchmarked with `CNN_EMG.py` after being processed into HDF
 
 To run the new dataset, input the dataset name to the dataset argument of `CNN_EMG.py`. Every subject must have data for all of the gestures in order for the dataset to be processed by `utils_generic.py`.
 
+NOTE: Images should be deleted when utils are updated. 
+
 ## Creating Custom Runs
 run_CNN_EMG.py also takes in config files. Create a new yaml file with your arguments and run: 
 ```

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ New datasets can be benchmarked with `CNN_EMG.py` after being processed into HDF
 
 To run the new dataset, input the dataset name to the dataset argument of `CNN_EMG.py`. Every subject must have data for all of the gestures in order for the dataset to be processed by `utils_generic.py`.
 
-NOTE: Saved images should be deleted any time utils are updated. Any additional arguments should be added to create_foldername_zarr() and set_wandb_runname().
+NOTE: Saved images should be deleted any time utils are updated. Additional arguments should be added to create_foldername_zarr() and set_wandb_runname().
 
 ## Creating Custom Runs
 run_CNN_EMG.py also takes in config files. Create a new yaml file with your arguments and run: 

--- a/Setup/Get_Datasets/process_MCS.py
+++ b/Setup/Get_Datasets/process_MCS.py
@@ -10,12 +10,24 @@ import os
 from glob import glob
 import torch
 
-# introduce an arg parse
+
+# introduce an arg parse to take in args.include_transitions
+
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+    
 import argparse
 parser = argparse.ArgumentParser(description="Include arguments for loading different data files")
-parser.add_argument("--include_transitions", type=bool, help="Start labeling gestures as soon as cue begins. Defaults to False.", default=True)
+parser.add_argument("--include_transitions", type=str2bool, help="Start labeling gestures as soon as cue begins. Defaults to False.", default=False)
 args = parser.parse_args()
-
+print("include_transitions is set to:", args.include_transitions)
 # Sampling rate "Hz"
 fs = 2000
 gesture_names = ['Rest', 'Extension', 'Flexion', 'Ulnar_Deviation', 'Radial_Deviation', 'Grip', 'Abduction', 'Adduction', 'Supination', 'Pronation']

--- a/Setup/Setup.py
+++ b/Setup/Setup.py
@@ -187,7 +187,9 @@ class Setup():
             from .Utils import utils_UCI as utils
             self.project_name = 'emg_benchmarking_uci'
             self.args.dataset = "uciemg"
-            utils.include_transitions = True
+
+            if self.args.include_transitions: 
+                utils.include_transitions = True
 
         elif (self.args.dataset in {"ninapro-db2", "ninapro_db2"}):
             if (not os.path.exists("./NinaproDB2")):

--- a/Setup/Setup.py
+++ b/Setup/Setup.py
@@ -153,6 +153,16 @@ class Setup():
             script_path = os.path.abspath(os.path.join(setup_dir, f"Get_Datasets/{dataset}.sh"))
             subprocess.run(['sh', script_path])
 
+        def process_dataset(dataset, params=''):
+            """
+            Downloads dataset in the root rather than in Setup directory.
+            """
+            setup_dir = os.path.dirname(__file__)
+            script_path = os.path.abspath(os.path.join(setup_dir, f"Get_Datasets/{dataset}.py"))
+            subprocess.run(['python', script_path, params])
+
+
+
         """ Conducts safety checks on the self.args, downloads needed datasets, and imports the correct self.utils file. """
         
         self.exercises = False
@@ -278,7 +288,19 @@ class Setup():
             if (not os.path.exists("./MCS_EMG")):
                 print("MCS dataset does not exist yet. Downloading now...")
                 get_dataset("get_MCS_EMG")
-                get_dataset("process_MCS")
+            
+            if self.args.include_transitions: 
+                if (not os.path.exists("./DatasetsProcessed_hdf5/MCS_EMG_include_transitions/")):
+                    print("MCS dataset not yet processed. Processing now")
+                    process_dataset("process_MCS", "--include_transitions=True")
+
+                utils.include_transitions = True
+
+            else: 
+                if (not os.path.exists("./DatasetsProcessed_hdf5/MCS_EMG/")):
+                    print("MCS dataset not yet processed. Processing now")
+                    process_dataset("process_MCS", "--include_transitions=False")      
+                utils.include_transitions = False      
            
             self.project_name = 'emg_benchmarking_mcs'
             if self.args.full_dataset_mcs:

--- a/Setup/Setup.py
+++ b/Setup/Setup.py
@@ -61,7 +61,7 @@ class Setup():
         # Arguments for run_CNN_EMG/using config files
         parser.add_argument('--config', type=str, help="Path to the config file.")
         parser.add_argument('--table', type=str, help="Specify which table to replicate. (Ex: 1, 2, 3, 3_intersession)")
-
+        parser.add_argument("--include_transitions", type=utils.str2bool, help="Whether or not to include transitions windows and label them as the final gesture. Set to False by default.", default=False)
         parser.add_argument("--multiprocessing", type=utils.str2bool, help="Whether or not to use multiprocessing when acquiring data. Set to True by default.", default=True)
         parser.add_argument("--force_regression", type=utils.str2bool, help="Regression between EMG and force data", default=False)
         parser.add_argument('--dataset', help='dataset to test. Set to MCS_EMG by default', default="MCS_EMG")

--- a/Setup/Setup.py
+++ b/Setup/Setup.py
@@ -187,6 +187,7 @@ class Setup():
             from .Utils import utils_UCI as utils
             self.project_name = 'emg_benchmarking_uci'
             self.args.dataset = "uciemg"
+            utils.include_transitions = True
 
         elif (self.args.dataset in {"ninapro-db2", "ninapro_db2"}):
             if (not os.path.exists("./NinaproDB2")):

--- a/Setup/Utils/utils_NinaproDB2.py
+++ b/Setup/Utils/utils_NinaproDB2.py
@@ -167,7 +167,7 @@ def balance(restimulus, args):
  
     
     # Calculate average count of non-zero elements
-    non_zero_counts = [count for key, count in count_dict.items() if key != 0]
+    non_zero_counts = [count for key, count in count_dict.items() if key != (0,)]
     if non_zero_counts:
         avg_count = sum(non_zero_counts) / len(non_zero_counts)
     else:

--- a/Setup/Utils/utils_NinaproDB3.py
+++ b/Setup/Utils/utils_NinaproDB3.py
@@ -170,7 +170,7 @@ def balance(restimulus, args):
  
     
     # Calculate average count of non-zero elements
-    non_zero_counts = [count for key, count in count_dict.items() if key != 0]
+    non_zero_counts = [count for key, count in count_dict.items() if key != (0,)]
     if non_zero_counts:
         avg_count = sum(non_zero_counts) / len(non_zero_counts)
     else:

--- a/Setup/Utils/utils_NinaproDB3.py
+++ b/Setup/Utils/utils_NinaproDB3.py
@@ -114,10 +114,10 @@ def getPartialEMG (args):
     emg = torch.from_numpy(io.loadmat(f'./NinaproDB3/DB3_s{n}/S{n}_E{exercise}_A1.mat')['emg']).to(torch.float16)
     return filter(emg.unfold(dimension=0, size=wLenTimesteps, step=stepLen)[balance(restim)])
 
-def getPartialLabels (args):
-    n, exercise = args
+def getPartialLabels (inputs):
+    n, exercise, args = inputs
     restim = getRestim(n, exercise)
-    return contract(restim[balance(restim)])
+    return contract(restim=restim[balance(restimulus=restim, args=args)], args=args)
         
 def str2bool(v):
     if isinstance(v, bool):
@@ -134,13 +134,14 @@ def seed_worker(worker_id):
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 
-def balance (restimulus):
+def balance(restimulus, args):
     """ Balances distribution of restimulus by minimizing zero (rest) gestures.
 
     Args:
         restimulus (tensor): restimulus tensor
-    """
+        args: argument parser object
 
+    """
     numZero = 0
     indices = []
     count_dict = {}
@@ -150,10 +151,23 @@ def balance (restimulus):
         unique_elements = torch.unique(restimulus[x])
         if len(unique_elements) == 1:
             element = unique_elements.item()
+            element = (element, )
             if element in count_dict:
                 count_dict[element] += 1
             else:
                 count_dict[element] = 1
+
+        else:
+            if args.include_transitions:
+                elements = (restimulus[x][0][0].item(), restimulus[x][0][-1].item()) # take first and last gesture (transition window)
+
+                # elements = int(str(restimulus[x][0][0].item()) + str(restimulus[x][0][-1].item())) # TODO: Figure out why dict keys have to be ints. Making them tuples or strings leads to different dimensions for X and Y for some reason. This is a hacky way to get around it. 
+                if elements in count_dict:
+                    count_dict[elements] += 1
+                else:
+                    count_dict[elements] = 1
+                
+ 
     
     # Calculate average count of non-zero elements
     non_zero_counts = [count for key, count in count_dict.items() if key != 0]
@@ -172,10 +186,13 @@ def balance (restimulus):
                 numZero += 1
             else:
                 indices.append(x)
+        else:
+            if args.include_transitions:
+                indices.append(x)
                 
     return indices
 
-def contract(restim, unfold=True):
+def contract(restim, args):
     """Converts restimulus tensor to one-hot encoded tensor.
 
     Args:
@@ -188,12 +205,17 @@ def contract(restim, unfold=True):
     numGestures = restim.max() + 1 # + 1 to account for rest gesture
     labels = torch.tensor(())
     labels = labels.new_zeros(size=(len(restim), numGestures))
-    if unfold:
-        for x in range(len(restim)):
-            labels[x][int(restim[x][0][0])] = 1.0
-    else:
-        for x in range(len(restim)):
-            labels[x][int(restim[x][0])] = 1.0
+  
+    for x in range(len(restim)):
+
+        if args.include_transitions:
+            gesture = int(restim[x][0][-1]) # take the last gesture it belongs to (labels the transition as part of the gesture)
+        else:
+            gesture = int(restim[x][0][0])
+            
+        gesture = make_gesture_sequential(gesture, args)
+        labels[x][gesture] = 1.0
+    
     return labels
 
 def filter(emg):
@@ -273,9 +295,15 @@ def getEMG (input):
     if (is_target_normalize and n != leftout):
         emg = target_normalize(emg, target_min, target_max, np.array(getRestim(n, exercise, unfold=False)))
 
-    restim = getRestim(n, exercise, unfold=True)
     emg = torch.from_numpy(emg).to(torch.float16)
-    return filter(emg.unfold(dimension=0, size=wLenTimesteps, step=stepLen)[balance(restim)]) # (WINDOWS, ELECTRODE, TIME STEP)
+    emg = emg.unfold(dimension=0, size=wLenTimesteps, step=stepLen) # (WINDOWS, ELECTRODE, TIME STEP)
+    
+    restim = getRestim(n, exercise)
+    balanced_indices = balance(restimulus=restim, args=args)
+
+    emg = emg[balanced_indices]
+    
+    return filter(emg)
 
 def get_decrements(args):
     """
@@ -292,7 +320,7 @@ def get_decrements(args):
     exercises = tuple(args.exercises)
     return decrements[exercises]
 
-def make_gestures_sequential(balanced_restim, args):
+def make_gesture_sequential(gesture, args):
     """
     Removes missing gaps between gestures depending on which exercises are selected.
 
@@ -306,16 +334,14 @@ def make_gestures_sequential(balanced_restim, args):
    
     exercise_starts = {1: 1, 2: 18, 3: 41}
     decrements = get_decrements(args)
-    for x in range(len(balanced_restim)): 
-        value = balanced_restim[x][0][0] # TODO: break here and check why its [x][0][0]
 
-        if value != 0:
-            exercise = (max(ex for ex in exercise_starts if exercise_starts[ex] <= value))-1
-            d = decrements[exercise]
-    
-            balanced_restim[x][0][0] = value - d
+    if gesture != 0: 
+        exercise_group = (max(ex for ex in exercise_starts if exercise_starts[ex] <= gesture))-1
+        d = decrements[exercise_group]
+    else:
+        d = 0
 
-    return balanced_restim
+    return gesture - d
 
 def getLabels (input):
     """Returns one-hot-encoding labels for a given participant and exercise. Labels are balanced (reduced rest gestures) and are sequential (no gaps between gestures of different exercises).
@@ -330,14 +356,9 @@ def getLabels (input):
     """
 
     n, exercise, args = input
-
-    if args.force_regression and n == MISSING_SUBJECT:
-        return None
-
     restim = getRestim(n, exercise)             
-    balanced_restim = restim[balance(restim)]   # (WINDOW, GESTURE, TIME STEP) 
-    ordered_restim = make_gestures_sequential(balanced_restim, args) 
-    return contract(ordered_restim)
+    balanced_restim = restim[balance(restimulus=restim, args=args)]   # (WINDOW, GESTURE, TIME STEP) 
+    return contract(restim=balanced_restim, args=args)
 
 def getExtrema (n, proportion, exercise, args):
     """Returns the min max of the electrode per gesture for a proportion of its windows. 
@@ -386,7 +407,7 @@ def getExtrema (n, proportion, exercise, args):
 
     return mins, maxes
            
-def getForces(input):
+def getForces(inputs):
     """Returns force data for a given participant and exercise. Forces are balanced (reduced rest gestures) and sequential (no gaps between gestures of different exercises).
 
     Args:
@@ -395,11 +416,11 @@ def getForces(input):
     Returns:
         _type_: _description_
     """
-    n, exercise = input
+    n, exercise, args = inputs
 
     if n == MISSING_SUBJECT: 
         return None
-        # implicitly, args.force_regression 
+        # implicitly, args.force_regression=True here
 
     assert exercise == 3, "Only exercise 3 has force data"
     force = torch.from_numpy(io.loadmat(f'./NinaproDB3/DB3_s{n}/S{n}_E{exercise}_A1.mat')['force'])

--- a/Setup/Utils/utils_NinaproDB5.py
+++ b/Setup/Utils/utils_NinaproDB5.py
@@ -116,7 +116,7 @@ def balance(restimulus, args):
         unique_elements = torch.unique(restimulus[x])
         if len(unique_elements) == 1:
             element = unique_elements.item()
-            element = (element, )
+            element = (element,)
             if element in count_dict:
                 count_dict[element] += 1
             else:
@@ -132,7 +132,7 @@ def balance(restimulus, args):
                     count_dict[elements] = 1
                 
     # Calculate average count of non-zero elements
-    non_zero_counts = [count for key, count in count_dict.items() if key != 0]
+    non_zero_counts = [count for key, count in count_dict.items() if key != (0,)]
     if non_zero_counts:
         avg_count = sum(non_zero_counts) / len(non_zero_counts)
     else:

--- a/Setup/Utils/utils_NinaproDB5.py
+++ b/Setup/Utils/utils_NinaproDB5.py
@@ -99,13 +99,14 @@ def seed_worker(worker_id):
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 
-def balance(restimulus):
+def balance(restimulus, args):
     """ Balances distribution of restimulus by minimizing zero (rest) gestures.
 
     Args:
         restimulus (tensor): restimulus tensor
-    """
+        args: argument parser object
 
+    """
     numZero = 0
     indices = []
     count_dict = {}
@@ -115,11 +116,21 @@ def balance(restimulus):
         unique_elements = torch.unique(restimulus[x])
         if len(unique_elements) == 1:
             element = unique_elements.item()
+            element = (element, )
             if element in count_dict:
                 count_dict[element] += 1
             else:
                 count_dict[element] = 1
-    
+
+        else:
+            if args.include_transitions:
+                elements = (restimulus[x][0][0].item(), restimulus[x][0][-1].item()) # take first and last gesture (transition window)
+
+                if elements in count_dict:
+                    count_dict[elements] += 1
+                else:
+                    count_dict[elements] = 1
+                
     # Calculate average count of non-zero elements
     non_zero_counts = [count for key, count in count_dict.items() if key != 0]
     if non_zero_counts:
@@ -137,10 +148,13 @@ def balance(restimulus):
                 numZero += 1
             else:
                 indices.append(x)
+        else:
+            if args.include_transitions:
+                indices.append(x)
                 
     return indices
 
-def contract(restim, unfold=True):
+def contract(restim, args):
     """Converts restimulus tensor to one-hot encoded tensor.
 
     Args:
@@ -153,12 +167,17 @@ def contract(restim, unfold=True):
     numGestures = restim.max() + 1 # + 1 to account for rest gesture
     labels = torch.tensor(())
     labels = labels.new_zeros(size=(len(restim), numGestures))
-    if unfold:
-        for x in range(len(restim)):
-            labels[x][int(restim[x][0][0])] = 1.0
-    else:
-        for x in range(len(restim)):
-            labels[x][int(restim[x][0])] = 1.0
+  
+    for x in range(len(restim)):
+
+        if args.include_transitions:
+            gesture = int(restim[x][0][-1]) # take the last gesture it belongs to (labels the transition as part of the gesture)
+        else:
+            gesture = int(restim[x][0][0])
+            
+        gesture = make_gesture_sequential(gesture, args)
+        labels[x][gesture] = 1.0
+    
     return labels
 
 def filter(emg):
@@ -257,7 +276,7 @@ def getEMG(input):
         emg = torch.tensor(emg.values)
 
     restim = getRestim(n, exercise, unfold=True)
-    return filter(emg.unfold(dimension=0, size=wLenTimesteps, step=stepLen)[balance(restim)])
+    return filter(emg.unfold(dimension=0, size=wLenTimesteps, step=stepLen)[balance(restim, args)])
     
 def get_decrements(args):
     """
@@ -274,7 +293,7 @@ def get_decrements(args):
     exercises = tuple(args.exercises)
     return decrements[exercises]
 
-def make_gestures_sequential(balanced_restim, args):
+def make_gesture_sequential(gesture, args):
     """
     Removes missing gaps between gestures depending on which exercises are selected.
 
@@ -288,19 +307,16 @@ def make_gestures_sequential(balanced_restim, args):
    
     exercise_starts = {1: 1, 2: 18, 3: 41}
     decrements = get_decrements(args)
-    for x in range(len(balanced_restim)): 
-        value = balanced_restim[x][0][0] # TODO: break here and check why its [x][0][0]
 
-        if value != 0:
-            exercise = (max(ex for ex in exercise_starts if exercise_starts[ex] <= value))-1
-            d = decrements[exercise]
-    
-            balanced_restim[x][0][0] = value - d
+    if gesture != 0: 
+        exercise_group = (max(ex for ex in exercise_starts if exercise_starts[ex] <= gesture))-1
+        d = decrements[exercise_group]
+    else:
+        d = 0
 
-    return balanced_restim
-
+    return gesture - d
   
-def getLabels (input, unfold=True):
+def getLabels (input):
     """Returns one-hot-encoding labels for a given participant and exercise. Labels are balanced (reduced rest gestures) and are sequential (no gaps between gestures of different exercises).
 
     Args:
@@ -314,9 +330,8 @@ def getLabels (input, unfold=True):
 
     n, exercise, args = input
     restim = getRestim(n, exercise)             
-    balanced_restim = restim[balance(restim)]    # (WINDOW, GESTURE, TIME STEP) 
-    ordered_restim = make_gestures_sequential(balanced_restim, args) 
-    return contract(ordered_restim)
+    balanced_restim = restim[balance(restimulus=restim, args=args)]   # (WINDOW, GESTURE, TIME STEP) 
+    return contract(restim=balanced_restim, args=args)
 
 def getExtrema (n, proportion, exercise, args):
     

--- a/Setup/Utils/utils_UCI.py
+++ b/Setup/Utils/utils_UCI.py
@@ -81,8 +81,13 @@ def balance (restimulus):
             if include_transitions:
                 start_gesture = restimulus[x][0] - 1
                 end_gesture = restimulus[x][-1] - 1 
-                if (start_gesture >= 0 and start_gesture <= 6) and (end_gesture >= 0 and end_gesture <= 6):
-                    indices.append(x) 
+            
+                if end_gesture >= 0 and end_gesture <= 6:
+                    indices.append(x)
+
+                    # Uncertain what Unmarked represents. Will include windows that go from Unmarked -> Gesture but not windows that go from Gesture -> Unmarked. 
+                
+          
     return indices
 
 def contract(R, unfold=True):

--- a/Setup/Utils/utils_UCI.py
+++ b/Setup/Utils/utils_UCI.py
@@ -85,8 +85,7 @@ def balance (restimulus):
                 if end_gesture >= 0 and end_gesture <= 6:
                     indices.append(x)
 
-                    # Uncertain what Unmarked represents. Will include windows that go from Unmarked -> Gesture but not windows that go from Gesture -> Unmarked. 
-                
+                    # Uncertain what Unmarked represents. Will include windows that go from Unmarked -> Gesture but not windows that go from Gesture -> Unmarked. (Unmarked is -1)
           
     return indices
 

--- a/Setup/Utils/utils_UCI.py
+++ b/Setup/Utils/utils_UCI.py
@@ -33,6 +33,8 @@ cmap = mpl.colormaps['viridis']
 gesture_labels = ["hand at rest","hand clenched in a fist","wrist flexion","wrist extension","radial deviations","ulnar deviations","extended palm"]
 gesture_labels = gesture_labels[:numGestures]
 
+include_transitions = False # Whether or not to include mixed gestures and label them as their last. Defined by Setup/Setup.py
+
 class CustomDataset(Dataset):
     def __init__(self, data, labels, transform=None):
         self.data = data
@@ -69,8 +71,18 @@ def seed_worker(worker_id):
 def balance (restimulus):
     indices = []
     for x in range (len(restimulus)):
-        if len(torch.unique(restimulus[x])) == 1 and restimulus[x][0] > 0 and restimulus[x][0] < 7:
-            indices.append(x)
+        unique_gestures = len(torch.unique(restimulus[x]))
+        if unique_gestures == 1: 
+            gesture = restimulus[x][0] - 1 # 0 is unmarked data, 1 rest, etc
+            if gesture >= 0 and gesture <= 6: 
+                indices.append(x)
+
+        else: 
+            if include_transitions:
+                start_gesture = restimulus[x][0] - 1
+                end_gesture = restimulus[x][-1] - 1 
+                if (start_gesture >= 0 and start_gesture <= 6) and (end_gesture >= 0 and end_gesture <= 6):
+                    indices.append(x) 
     return indices
 
 def contract(R, unfold=True):
@@ -78,7 +90,11 @@ def contract(R, unfold=True):
     labels = labels.new_zeros(size=(len(R), numGestures))
     if (unfold):
         for x in range(len(R)):
-            labels[x][int(R[x][0]) - 1] = 1.0
+            if include_transitions: 
+                gesture = int(R[x][-1]) -1 # take the last gesture of the window, subtract by 1 because 0 is unmarked data
+            else: 
+                gesture = int(R[x][0]) - 1 # take the first gesture of the window, subtract by 1 because 0 is unmarked data
+            labels[x][gesture] = 1.0
     else:
         for x in range(len(R)):
             labels[x][int(R[x]) - 1] = 1.0
@@ -102,9 +118,18 @@ def getRestim (n, unfold=True, session_number=1):
                 print("Reading file", file, "Subject", n)
             else:
                 continue
+
             if (unfold):
-                data = torch.from_numpy(np.loadtxt(os.path.join(f"uciEMG/{n}/", file), dtype=np.float32, skiprows=1)[:, 1:]).unfold(dimension=0, size=wLenTimesteps, step=stepLen)
-                restim.append(data[:, -1][balance(data[:, -1])])
+
+                file_path = os.path.join(f"uciEMG/{n}/", file)
+
+                data_numpy = np.loadtxt(file_path, dtype=np.float32, skiprows=1)[:, 1:] # ignore first row (header) and first column (time)
+                data_tensor = torch.from_numpy(data_numpy)
+                data_unfolded = data_tensor.unfold(dimension=0, size=wLenTimesteps, step=stepLen)
+                gesture_col = data_unfolded[:, -1] # take the gesture column
+                balanced_data = gesture_col[balance(gesture_col)]
+                restim.append(balanced_data)
+
             else:
                 data = torch.from_numpy(np.loadtxt(os.path.join(f"uciEMG/{n}/", file), dtype=np.float32, skiprows=1)[:, 1:])
                 restim.append(data[:, -1])
@@ -498,6 +523,9 @@ def getImages(emg, standardScaler, length, width, turn_on_rms=False, rms_windows
         for i in tqdm(range(len(emg)), desc="Creating CWT Images"):
             images_cwt_list.append(optimized_makeOneCWTImage(*args[i]))
         images = images_cwt_list
+
+    # elif turn_on_phase: 
+    #     # TODO: update the phase here 
         
     elif turn_on_hht:
         raise NotImplementedError("HHT is not implemented yet")


### PR DESCRIPTION
Added the argument "--include_transitions". For datasets DB2, DB3, DB5, UCIEMG, and MCS, for any mixed windows (i.e windows where there are multiple gestures), if include_transitions=True, we label the window of the last gesture in the window. This should help with real world classification as we are also learning emg leading up to the gesture. 

Main functions of focus: balance and contract. 

Further details: 
- **DB2**: Dataset includes transitions, update to label mixed windows as the last gesture in the window.
- **DB3**: Dataset includes transitions, update to label mixed windows as the last gesture in the window.
- **DB5**: Dataset includes transitions, update to label mixed windows as the last gesture in the window.
- **capgmyo** — Transitions not included in dataset: “We use the middle one second data to ensure that no transition movements are included in training and testing.”
- **hyser** — Transitions not  included in dataset: “The first 0.25 s reaction time after each task onset was removed, leaving 0.75 s and 3.75 s signals for dynamic and maintenance tasks, respectively”
- **myoarmbanddataset** — Transitions taken out: “ This rest period was not recorded and as a result, the final dataset is balanced for all classes.”
- **uciemg**: Dataset includes transitions, update to label mixed windows as the last gesture in the window. Note that there is a series of unmarked data in between each gesture. For include_transitions=True, we expand include windows that go from unmarked to a gesture. This likely covers transitions, but since we don’t know what is occurring in these time steps, it could include other behavior.
- **flexwear-hd**: Transitions not included in dataset.
- **mcs**: Dataset includes transitions, update to expand the window which we consider for the gesture. In study, each gesture is given 10 seconds: 0s→4s: Rest, 4s: Cue, 4s→10s: Hold Gesture. When include_transition=False, we narrow our gesture window to be 5s→10s making us confident that the entire window corresponds to holding the gesture. When include_transition=True, we open our window to be from cue, 4s→10s. This gives us more windows during that transition period from rest to gesture. One potential issue with this change is that it may lead to misclassifying rest windows as other gestures, particularly if a participant’s reaction time to the cue is larger than our window size of 250 ms. However, we believe that 250 ms is sufficient time and will not be a big issue.