### PR TITLE
Add transition classifier

### DIFF
--- a/CNN_EMG.py
+++ b/CNN_EMG.py
@@ -24,8 +24,6 @@ from Model.Unlabeled_Domain_Adaptation_Trainer import Unlabeled_Domain_Adaptatio
 from Model.MLP_Trainer import MLP_Trainer
 from Model.SVC_RF_Trainer import SVC_RF_Trainer
 
-
-
 class Run_Setup():
     """
     Sets up the run by reading in arguments, setting the dataset source, conducting safety checks, printing values and setting up env.

--- a/Data/Combined_Data.py
+++ b/Data/Combined_Data.py
@@ -67,6 +67,14 @@ class Combined_Data():
             self.env.num_gestures  = numGestures # different gesture count for Ninapro
             self.append_to_new_data(self.X.concatenated_trials, self.Y.concatenated_trials, self.label.concatenated_trials)
 
+            print(f"Subject {subject}: has {numGestures} gestures and self.label.shape {self.label.concatenated_trials.shape}") 
+
+            # turn self.label.concatenated_trails from one hot encoding to labels
+            gestures_to_append = np.argmax(self.label.concatenated_trials, axis=1)
+            unique, counts = np.unique(gestures_to_append, return_counts=True)
+            for i in unique:
+                print(f"Gesture {i}: {counts[i]} ")
+
         self.set_new_data()
 
         del self.X.new_data, self.Y.new_data, self.label.new_data
@@ -96,11 +104,7 @@ class Combined_Data():
 
                 if self.args.force_regression:
                     assert(exercise == 3), "Regression only implemented for exercise 3"
-                    forces_async = pool.map_async(self.utils.getForces, list(
-                        zip(
-                            [(i+1) for i in range(self.utils.num_subjects)], exercise*np.ones(self.utils.num_subjects).astype(int), 
-                            [self.args]*np.ones(self.utils.num_subjects).astype(int)
-                    )))
+                    forces_async = pool.map_async(self.utils.getForces, list(zip([(i+1) for i in range(self.utils.num_subjects)], exercise*np.ones(self.utils.num_subjects).astype(int))))
                     forces.append(forces_async.get())
                     
                 assert len(emg[-1]) == len(labels[-1]), "Number of trials for EMG and labels do not match"
@@ -113,9 +117,6 @@ class Combined_Data():
         else:
             self.Y.data = labels
         self.label.data = labels
-
-        for i in range(len(self.X.data[0])):
-            assert(len(self.X.data[0][i]) == len(self.Y.data[0][i])), "Number of windows for X and Y do not match."
 
     def load_other_datasets(self):
 

--- a/Data/Combined_Data.py
+++ b/Data/Combined_Data.py
@@ -67,14 +67,6 @@ class Combined_Data():
             self.env.num_gestures  = numGestures # different gesture count for Ninapro
             self.append_to_new_data(self.X.concatenated_trials, self.Y.concatenated_trials, self.label.concatenated_trials)
 
-            print(f"Subject {subject}: has {numGestures} gestures and self.label.shape {self.label.concatenated_trials.shape}") 
-
-            # turn self.label.concatenated_trails from one hot encoding to labels
-            gestures_to_append = np.argmax(self.label.concatenated_trials, axis=1)
-            unique, counts = np.unique(gestures_to_append, return_counts=True)
-            for i in unique:
-                print(f"Gesture {i}: {counts[i]} ")
-
         self.set_new_data()
 
         del self.X.new_data, self.Y.new_data, self.label.new_data

--- a/Data/Data.py
+++ b/Data/Data.py
@@ -210,3 +210,25 @@ class Data():
 
                 new_torch = torch.from_numpy(getattr(self, set_name)).to(torch.float16)
                 setattr(self, set_name, new_torch)
+
+    # Transition Classifier Helper
+    def transition_labels_to_binary(self):
+
+        for set_name in ["train", "validation", "test"]:
+                         
+            transition_labels = getattr(self, set_name)
+            binary_labels = torch.zeros((len(transition_labels), 2))
+
+            for i in range(len(transition_labels)):
+            
+                start_gesture = int(transition_labels[i][0])
+                end_gesture = int(transition_labels[i][1])
+
+                if start_gesture == end_gesture: 
+                    binary_labels[i][0] = 1.0
+                else:
+                    binary_labels[i][1] = 1.0
+
+            setattr(self, set_name, binary_labels)
+
+                         

--- a/Data/Label_Data.py
+++ b/Data/Label_Data.py
@@ -38,13 +38,15 @@ class Label_Data(Data):
         # Convert from one hot encoding to labels
         # Assuming labels are stored separately and need to be concatenated end-to-end
 
-
         labels_set = []
         index_to_start_at = 0
         for i in range(len(self.subject_trials)):
-            subject_labels_to_concatenate = [x + index_to_start_at if x != 0 else 0 for x in np.argmax(self.subject_trials[i], axis=1)]
-            if self.args.dataset == "ninapro-db5":
-                index_to_start_at = max(subject_labels_to_concatenate)
+            if self.args.transition_classifier: 
+                subject_labels_to_concatenate = self.subject_trials[i]
+            else: 
+                subject_labels_to_concatenate = [x + index_to_start_at if x != 0 else 0 for x in np.argmax(self.subject_trials[i], axis=1)]
+                if self.args.dataset == "ninapro-db5":
+                    index_to_start_at = max(subject_labels_to_concatenate)
             labels_set.append(subject_labels_to_concatenate)
 
         if self.args.partial_dataset_ninapro:
@@ -53,22 +55,34 @@ class Label_Data(Data):
         concatenated_labels = np.concatenate(labels_set, axis=0) # (TRIAL)
 
         indices_for_partial_dataset = None
+        
         if self.args.partial_dataset_ninapro:
-            indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
-            
-            concatenated_labels = concatenated_labels[indices_for_partial_dataset]
-        
-            # convert labels to indices
-            label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
-            concatenated_labels = [label_to_index[label] for label in concatenated_labels]
-        
-        numGestures = len(np.unique(concatenated_labels))
 
-        # Convert to one hot encoding
-        concatenated_labels = np.eye(np.max(concatenated_labels) + 1)[concatenated_labels] # (TRIAL, GESTURE)
+            if self.args.transition_classifier: 
+                desired_gesture_labels = self.utils.partial_gesture_indices
+                indices_for_partial_dataset = np.array([indices for indices, (start_gesture, end_gesture) in enumerate(concatenated_labels) if start_gesture in desired_gesture_labels and end_gesture in desired_gesture_labels])
+                concatenated_labels = concatenated_labels[indices_for_partial_dataset]
+                label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
+                concatenated_labels = [
+                    [label_to_index[start_gesture], label_to_index[end_gesture]] 
+                    for start_gesture, end_gesture in concatenated_labels
+                ]
+                concatenated_labels = np.array(concatenated_labels)
+            else:
+                desired_gesture_labels = self.utils.partial_gesture_indices
+                indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
+                concatenated_labels = concatenated_labels[indices_for_partial_dataset]
+                # convert labels to indices
+                label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
+                concatenated_labels = [label_to_index[label] for label in concatenated_labels]
+
+        numGestures = len(np.unique(concatenated_labels))
+        
+        if not self.args.transition_classifier:
+            # Convert to one hot encoding
+            concatenated_labels = np.eye(np.max(concatenated_labels) + 1)[concatenated_labels] # (TRIAL, GESTURE)
 
         self.concatenated_trials = concatenated_labels
-
         return numGestures, indices_for_partial_dataset
         
 

--- a/Data/Label_Data.py
+++ b/Data/Label_Data.py
@@ -47,20 +47,20 @@ class Label_Data(Data):
                 index_to_start_at = max(subject_labels_to_concatenate)
             labels_set.append(subject_labels_to_concatenate)
 
-        if self.args.partial_dataset_ninapro:
-            desired_gesture_labels = self.utils.partial_gesture_indices
+        # if self.args.partial_dataset_ninapro:
+        #     desired_gesture_labels = self.utils.partial_gesture_indices
 
         concatenated_labels = np.concatenate(labels_set, axis=0) # (TRIAL)
 
         indices_for_partial_dataset = None
-        if self.args.partial_dataset_ninapro:
-            indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
+        # if self.args.partial_dataset_ninapro:
+        #     indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
             
-            concatenated_labels = concatenated_labels[indices_for_partial_dataset]
+        #     concatenated_labels = concatenated_labels[indices_for_partial_dataset]
         
-            # convert labels to indices
-            label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
-            concatenated_labels = [label_to_index[label] for label in concatenated_labels]
+        #     # convert labels to indices
+        #     label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
+        #     concatenated_labels = [label_to_index[label] for label in concatenated_labels]
         
         numGestures = len(np.unique(concatenated_labels))
 

--- a/Data/Label_Data.py
+++ b/Data/Label_Data.py
@@ -11,16 +11,16 @@ import multiprocessing
 class Label_Data(Data):
 
     def __init__(self, env):
-            super().__init__("Label",env)
+        super().__init__("Label",env)
 
-            # Set seeds for reproducibility
-            np.random.seed(self.args.seed)
-            torch.manual_seed(self.args.seed)
-            torch.cuda.manual_seed(self.args.seed)
-            if torch.cuda.is_available():
-                torch.cuda.manual_seed_all(self.args.seed)
-            torch.backends.cudnn.deterministic = True
-            torch.backends.cudnn.benchmark = False
+        # Set seeds for reproducibility
+        np.random.seed(self.args.seed)
+        torch.manual_seed(self.args.seed)
+        torch.cuda.manual_seed(self.args.seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(self.args.seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
 
 
     # Process Ninapro Helper
@@ -47,20 +47,20 @@ class Label_Data(Data):
                 index_to_start_at = max(subject_labels_to_concatenate)
             labels_set.append(subject_labels_to_concatenate)
 
-        # if self.args.partial_dataset_ninapro:
-        #     desired_gesture_labels = self.utils.partial_gesture_indices
+        if self.args.partial_dataset_ninapro:
+            desired_gesture_labels = self.utils.partial_gesture_indices
 
         concatenated_labels = np.concatenate(labels_set, axis=0) # (TRIAL)
 
         indices_for_partial_dataset = None
-        # if self.args.partial_dataset_ninapro:
-        #     indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
+        if self.args.partial_dataset_ninapro:
+            indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
             
-        #     concatenated_labels = concatenated_labels[indices_for_partial_dataset]
+            concatenated_labels = concatenated_labels[indices_for_partial_dataset]
         
-        #     # convert labels to indices
-        #     label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
-        #     concatenated_labels = [label_to_index[label] for label in concatenated_labels]
+            # convert labels to indices
+            label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
+            concatenated_labels = [label_to_index[label] for label in concatenated_labels]
         
         numGestures = len(np.unique(concatenated_labels))
 

--- a/Data/X_Data.py
+++ b/Data/X_Data.py
@@ -58,8 +58,8 @@ class X_Data(Data):
         """
         self.concatenated_trials = np.concatenate(self.subject_trials, axis=0)
 
-        if self.args.partial_dataset_ninapro:
-            self.concatenated_trials = self.concatenated_trials[indices_for_partial_dataset]
+        # if self.args.partial_dataset_ninapro:
+        #     self.concatenated_trials = self.concatenated_trials[indices_for_partial_dataset]
 
     def create_foldername_zarr(self):
         base_foldername_zarr = ""
@@ -98,6 +98,10 @@ class X_Data(Data):
                 base_foldername_zarr += f'exercises{exercises_numbers_filename}/'
         if self.args.include_transitions: 
             base_foldername_zarr += 'include_transitions/'
+
+        if self.args.transition_classifier: 
+            base_foldername_zarr += 'transition_classifier/'
+
         if self.args.save_images: 
             if not os.path.exists(base_foldername_zarr):
                 os.makedirs(base_foldername_zarr)

--- a/Data/X_Data.py
+++ b/Data/X_Data.py
@@ -58,8 +58,8 @@ class X_Data(Data):
         """
         self.concatenated_trials = np.concatenate(self.subject_trials, axis=0)
 
-        # if self.args.partial_dataset_ninapro:
-        #     self.concatenated_trials = self.concatenated_trials[indices_for_partial_dataset]
+        if self.args.partial_dataset_ninapro:
+            self.concatenated_trials = self.concatenated_trials[indices_for_partial_dataset]
 
     def create_foldername_zarr(self):
         base_foldername_zarr = ""

--- a/Data/Y_Data.py
+++ b/Data/Y_Data.py
@@ -54,13 +54,16 @@ class Y_Data(Data):
 
             concatenated_labels = np.concatenate(labels_set, axis=0) # (TRIAL)
 
-            # if self.args.partial_dataset_ninapro:
-            #     desired_gesture_labels = self.utils.partial_gesture_indices
-            #     indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
-            #     concatenated_labels = concatenated_labels[indices_for_partial_dataset]
-            #     # convert labels to indices
-            #     label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
-            #     concatenated_labels = [label_to_index[label] for label in concatenated_labels]
+            # TODO: Need to cut the indices differently based on if we are are using transition_classifier since the gestures will be [start, end], should check the end of the gestures and see if its in the one 
+
+            
+            if self.args.partial_dataset_ninapro:
+                desired_gesture_labels = self.utils.partial_gesture_indices
+                indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
+                concatenated_labels = concatenated_labels[indices_for_partial_dataset]
+                # convert labels to indices
+                label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
+                concatenated_labels = [label_to_index[label] for label in concatenated_labels]
 
             # Convert to one hot encoding
             concatenated_labels = np.eye(np.max(concatenated_labels) + 1)[concatenated_labels] # (TRIAL, GESTURE)

--- a/Data/Y_Data.py
+++ b/Data/Y_Data.py
@@ -52,17 +52,15 @@ class Y_Data(Data):
                     index_to_start_at = max(subject_labels_to_concatenate)
                 labels_set.append(subject_labels_to_concatenate)
 
-            if self.args.partial_dataset_ninapro:
-                desired_gesture_labels = self.utils.partial_gesture_indices
-
             concatenated_labels = np.concatenate(labels_set, axis=0) # (TRIAL)
 
-            if self.args.partial_dataset_ninapro:
-                indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
-                concatenated_labels = concatenated_labels[indices_for_partial_dataset]
-                # convert labels to indices
-                label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
-                concatenated_labels = [label_to_index[label] for label in concatenated_labels]
+            # if self.args.partial_dataset_ninapro:
+            #     desired_gesture_labels = self.utils.partial_gesture_indices
+            #     indices_for_partial_dataset = np.array([indices for indices, label in enumerate(concatenated_labels) if label in desired_gesture_labels])
+            #     concatenated_labels = concatenated_labels[indices_for_partial_dataset]
+            #     # convert labels to indices
+            #     label_to_index = {label: index for index, label in enumerate(desired_gesture_labels)}
+            #     concatenated_labels = [label_to_index[label] for label in concatenated_labels]
 
             # Convert to one hot encoding
             concatenated_labels = np.eye(np.max(concatenated_labels) + 1)[concatenated_labels] # (TRIAL, GESTURE)

--- a/Model/CNN_Trainer.py
+++ b/Model/CNN_Trainer.py
@@ -70,7 +70,7 @@ class CNN_Trainer(Model_Trainer):
             self.model = resnet50(weights=ResNet50_Weights.DEFAULT)
             # Replace the last fully connected layer
             num_ftrs = self.model.fc.in_features  # Get the number of input features of the original fc layer
-            self.model.fc = nn.Linear(num_ftrs, self.num_gestures)  # Replace with a new linear layer
+            self.model.fc = nn.Linear(num_ftrs, self.num_classes)  # Replace with a new linear layer
 
         elif self.args.model == 'convnext_tiny_custom':
             class LayerNorm2d(nn.LayerNorm):
@@ -85,7 +85,7 @@ class CNN_Trainer(Model_Trainer):
 
             n_inputs = 768
             hidden_size = 128 # default is 2048
-            n_outputs = self.num_gestures
+            n_outputs = self.num_classes
 
             # self.model = timm.create_model(self.model_name, pretrained=True, num_classes=10)
             self.model = convnext_tiny(weights=ConvNeXt_Tiny_Weights.DEFAULT)
@@ -112,13 +112,13 @@ class CNN_Trainer(Model_Trainer):
 
         elif self.args.model == 'vit_tiny_patch2_32':
             pretrain_path = "https://github.com/microsoft/Semi-supervised-learning/releases/download/v.0.0.0/vit_tiny_patch2_32_mlp_im_1k_32.pth"
-            self.model = VisualTransformer.vit_tiny_patch2_32(pretrained=True, pretrained_path=pretrain_path, num_classes=self.num_gestures)
+            self.model = VisualTransformer.vit_tiny_patch2_32(pretrained=True, pretrained_path=pretrain_path, num_classes=self.num_classes)
 
         elif self.args.model not in ["MLP", "SVC", "RF"]:
             if self.args.force_regression: 
                 self.model = timm.create_model(self.model_name, pretrained=True, num_classes=self.Y.validation.shape[1])
             else: 
-                self.model = timm.create_model(self.model_name, pretrained=True, num_classes=self.num_gestures)
+                self.model = timm.create_model(self.model_name, pretrained=True, num_classes=self.num_classes)
 
 
     def set_param_requires_grad(self):
@@ -210,7 +210,7 @@ class CNN_Trainer(Model_Trainer):
         """
 
         # Evaluate performance on test metrics
-        ml_utils.evaluate_model_on_test_set(self.model, self.test_loader, self.device, self.num_gestures, self.criterion, self.args, testing_metrics)
+        ml_utils.evaluate_model_on_test_set(self.model, self.test_loader, self.device, self.num_classes, self.criterion, self.args, testing_metrics)
 
         if not self.args.force_regression:
             self.print_classification_metrics()
@@ -321,8 +321,8 @@ class CNN_Trainer(Model_Trainer):
             train_loss /= len(finetune_loader)
             val_loss /= len(self.val_loader)
             if not self.args.force_regression: 
-                tpr_results = ml_utils.evaluate_model_tpr_at_fpr(self.model, self.val_loader, self.device, self.num_gestures)
-                fpr_results = ml_utils.evaluate_model_fpr_at_tpr(self.model, self.val_loader, self.device, self.num_gestures)
+                tpr_results = ml_utils.evaluate_model_tpr_at_fpr(self.model, self.val_loader, self.device, self.num_classes)
+                fpr_results = ml_utils.evaluate_model_fpr_at_tpr(self.model, self.val_loader, self.device, self.num_classes)
                 confidence_levels, proportions_above_confidence_threshold = ml_utils.evaluate_confidence_thresholding(self.model, self.val_loader, self.device)
 
             # Compute the metrics and store them in dictionaries (to prevent multiple calls to compute)
@@ -378,7 +378,7 @@ class CNN_Trainer(Model_Trainer):
 
         # Evaluate the self.model on the test set
         ml_utils.evaluate_model_on_test_set(self.model, self.test_loader, self.
-        device, self.num_gestures, self.criterion, self.args, testing_metrics)
+        device, self.num_classes, self.criterion, self.args, testing_metrics)
 
         if not self.args.force_regression:
             self.print_classification_metrics()

--- a/Model/CNN_Trainer.py
+++ b/Model/CNN_Trainer.py
@@ -406,10 +406,10 @@ class CNN_Trainer(Model_Trainer):
 
                 for X_batch, Y_batch in t:
                     X_batch = X_batch.to(self.device).to(torch.float32)
-                    Y_batch =Y_batch.to(self.device).to(torch.float32) # ground truth
+                    Y_batch = Y_batch.to(self.device).to(torch.float32) # ground truth
 
                     if self.args.force_regression:
-                       Y_batch_long =Y_batch
+                       Y_batch_long = Y_batch
                     else: 
                        Y_batch_long = torch.argmax(Y_batch, dim=1)
 

--- a/Model/Model_Trainer.py
+++ b/Model/Model_Trainer.py
@@ -426,6 +426,7 @@ class Model_Trainer():
     def plot_test_images(self):
         self.utils.plot_average_images(self.X.test, np.argmax(self.label.test.cpu().detach().numpy(), axis=1), self.gesture_labels, self.testrun_foldername, self.args, self.formatted_datetime, 'test')
         self.utils.plot_first_fifteen_images(self.X.test, np.argmax(self.label.test.cpu().detach().numpy(), axis=1), self.gesture_labels, self.testrun_foldername, self.args, self.formatted_datetime, 'test')
+        
 
     def plot_validation_images(self):
 

--- a/Model/Model_Trainer.py
+++ b/Model/Model_Trainer.py
@@ -151,11 +151,37 @@ class Model_Trainer():
                 metric.name = name
             
             return classification_metrics
+        
+
+        def get_transition_classifier_metrics():
+            classification_metrics = [
+
+                torchmetrics.Accuracy(task="multiclass", num_classes=self.num_classes, average="macro").to(self.device),
+                torchmetrics.Precision(task="multiclass", num_classes=self.num_classes, average="macro").to(self.device),
+                torchmetrics.Recall(task="multiclass", num_classes=self.num_classes, average="macro").to(self.device),
+                torchmetrics.F1Score(task="multiclass", num_classes=self.num_classes, average="macro").to(self.device),
+                torchmetrics.Accuracy(top_k=1, task="multiclass", num_classes=self.num_classes, average="macro").to(self.device),
+                torchmetrics.Accuracy(task="multiclass", num_classes=self.num_classes, average="micro").to(self.device),
+                torchmetrics.Accuracy(top_k=1, task="multiclass", num_classes=self.num_classes, average="micro").to(self.device),
+                torchmetrics.AUROC(task="multiclass", num_classes=self.num_classes, average="macro").to(self.device),
+                torchmetrics.AveragePrecision(task="multiclass", num_classes=self.num_classes, average="macro").to(self.device)
+            ]
+            for metric, name in zip(classification_metrics, ["Macro_Acc", "Macro_Precision", "Macro_Recall", "Macro_F1Score", "Macro_Top5Accuracy", "Micro_Accuracy", "Micro_Top5Accuracy", "Macro_AUROC","Macro_AUPRC"]):
+                metric.name = name
             
+            return classification_metrics
+        
+
+         
         if self.args.force_regression:
             training_metrics = get_regression_metrics()
             validation_metrics = get_regression_metrics()
             testing_metrics = get_regression_metrics()
+
+        elif self.args.transition_classifier:
+            training_metrics = get_transition_classifier_metrics()
+            validation_metrics = get_transition_classifier_metrics()
+            testing_metrics = get_transition_classifier_metrics()
 
         else: 
             training_metrics = get_classification_metrics()
@@ -284,6 +310,9 @@ class Model_Trainer():
     
     def set_wandb_runname(self):
         wandb_runname = 'CNN_seed-'+str(self.args.seed)
+
+        if self.args.transition_classifier:
+            wandb_runname += '_transition_classifier'
         if self.args.turn_on_rms:
             wandb_runname += '_rms-'+str(self.args.rms_input_windowsize)
         if self.args.leftout_subject != 0:
@@ -377,17 +406,19 @@ class Model_Trainer():
         self.model_filename = f'{self.testrun_foldername}model_{self.formatted_datetime}.pth'
 
     def set_gesture_labels(self):
-        if (self.exercises):
-            if not self.args.partial_dataset_ninapro:
-                self.gesture_labels = self.utils.gesture_labels['Rest']
-                for exercise_set in self.args.exercises:
-                    self.gesture_labels = self.gesture_labels + self.utils.gesture_labels[exercise_set]
-            else:
-                self.gesture_labels = self.utils.partial_gesture_labels
-        else:
-            self.gesture_labels = self.utils.gesture_labels
 
-        self.gesture_labels = self.gesture_labels
+        if self.args.transition_classifier:
+            self.gesture_labels = self.utils.transition_labels
+        else: 
+            if (self.exercises):
+                if not self.args.partial_dataset_ninapro:
+                    self.gesture_labels = self.utils.gesture_labels['Rest']
+                    for exercise_set in self.args.exercises:
+                        self.gesture_labels = self.gesture_labels + self.utils.gesture_labels[exercise_set]
+                else:
+                    self.gesture_labels = self.utils.partial_gesture_labels
+            else:
+                self.gesture_labels = self.utils.gesture_labels
 
     def plot_test_images(self):
         self.utils.plot_average_images(self.X.test, np.argmax(self.label.test.cpu().detach().numpy(), axis=1), self.gesture_labels, self.testrun_foldername, self.args, self.formatted_datetime, 'test')
@@ -450,10 +481,14 @@ class Model_Trainer():
         if self.args.force_regression:
             num_classes = self.Y.train.shape[1]
             # assert num_classes == 6
+        elif self.args.transition_classifier:
+            num_classes = 2
         else: 
             num_classes = self.num_gestures
 
         self.num_classes = num_classes
+
+
 
     def shared_setup(self):
         # set up function calls shared for all models 

--- a/Setup/Setup.py
+++ b/Setup/Setup.py
@@ -173,7 +173,6 @@ class Setup():
             self.args.include_transitions = True
 
         if self.args.include_transitions:
-
             transition_datasets = {"ninapro-db2", "ninapro_db2", "ninapro-db5", "ninapro_db5", "ninapro-db3", "ninapro_db3", "uciemg", "uci", "mcs"}
             assert self.args.dataset in transition_datasets, f"Transitions from rest to gesture are only preserved in {transition_datasets} datasets."
 

--- a/Setup/Setup.py
+++ b/Setup/Setup.py
@@ -162,8 +162,6 @@ class Setup():
             script_path = os.path.abspath(os.path.join(setup_dir, f"Get_Datasets/{dataset}.py"))
             subprocess.run(['python', script_path, params])
 
-
-
         """ Conducts safety checks on the self.args, downloads needed datasets, and imports the correct self.utils file. """
         
         self.exercises = False
@@ -207,11 +205,15 @@ class Setup():
                 assert self.args.exercises == [3], "Regression only implemented for exercise 3"
             self.args.dataset = 'ninapro-db2'
 
-        elif (self.args.dataset in { "ninapro-db5", "ninapro_db5"}):
+        elif (self.args.dataset in {"ninapro-db5", "ninapro_db5"}):
             if (not os.path.exists("./NinaproDB5")):
                 print("NinaproDB5 dataset does not exist yet. Downloading now...")
                 get_dataset("get_NinaproDB5")
-                get_dataset("process_NinaproDB5")
+
+            if (not os.path.exists("./DatasetsProcessed_hdf5/NinaproDB5/")):
+                print("NinaproDB5 dataset not yet processed. Processing now")
+                process_dataset("process_NinaproDB5")
+
             from .Utils import utils_NinaproDB5 as utils
             self.project_name = 'emg_benchmarking_ninapro-db5'
             self.exercises = True
@@ -300,6 +302,7 @@ class Setup():
                     print("MCS dataset not yet processed. Processing now")
                     process_dataset("process_MCS", "--transition_classifier=True")
 
+                # TODO: Pass in arg parse to utils and use that instead
                 utils.include_transitions = True
                 utils.transition_classifier = True
 

--- a/Setup/Setup.py
+++ b/Setup/Setup.py
@@ -348,6 +348,9 @@ class Setup():
             self.args.target_normalize_subject = self.args.leftout_subject
             print("Target normalize subject defaulting to leftout subject.")
 
+        if self.args.transition_classifier:
+            assert self.args.leave_one_subject_out, "Binary classifier only implemented for LOSO."
+
         
 
         # Add date and time to filename

--- a/Setup/Utils/utils_MCS_EMG.py
+++ b/Setup/Utils/utils_MCS_EMG.py
@@ -184,23 +184,37 @@ def getExtrema (n, proportion):
 
 def getLabels_transition_classificatier(n):
     """
-    One-hot encoding for transition classifier. For the first second of the window (the second immediately after cue), label as Transition. All other windows are labeled as No Transition. 
+    
     """
 
+    # Need to return labels of type (start, end) per window
 
     # Balanced windows out: [Transition][No Transiton], 2 seconds total
     timesteps_for_one_gesture = 20 * 2 
     timsteps_for_one_second = 20 
 
-    labels = np.zeros(((timesteps_for_one_gesture)*numGestures, 2))
+    # labels = np.zeros(((timesteps_for_one_gesture)*numGestures, 2))
+
+    transition_labels = torch.zeros(((timesteps_for_one_gesture)*numGestures, 2), dtype=torch.float32)
+
     for i in range(timesteps_for_one_gesture):
         for j in range(numGestures):
 
+            current_window = (j * timesteps_for_one_gesture) + i
+            
+            # the first second is transition
             if i <= timsteps_for_one_second:
-                labels[j * timesteps_for_one_gesture + i][1] = 1.0
+
+                transition_labels[current_window] = torch.tensor([-1, j], dtype=torch.float32)
+
+                # labels[j * timesteps_for_one_gesture + i][1] = 1.0
+
+            # the next second is non transtion
             elif timsteps_for_one_second < i < 2 * timsteps_for_one_second:
-                labels[j * timesteps_for_one_gesture + i][0] = 1.0
-    return labels
+                
+                transition_labels[current_window] = torch.tensor([j, j], dtype=torch.float32)
+
+    return transition_labels
 
 
 def getLabels_gesture_classificatier(n):

--- a/Setup/Utils/utils_NinaproDB2.py
+++ b/Setup/Utils/utils_NinaproDB2.py
@@ -30,7 +30,7 @@ cmap = mpl.colormaps['viridis']
 # Gesture Labels
 gesture_labels = {}
 gesture_labels['Rest'] = ['Rest'] # Shared between exercises
-transition_labels = ['Not a Transition', 'Transition'] 
+
 
 gesture_labels[1] = ['Thumb Up', 'Index Middle Extension', 'Ring Little Flexion', 'Thumb Opposition', 'Finger Abduction', 'Fist', 'Pointing Index', 'Finger Adduction',
                     'Middle Axis Supination', 'Middle Axis Pronation', 'Little Axis Supination', 'Little Axis Pronation', 'Wrist Flexion', 'Wrist Extension', 'Radial Deviation',
@@ -48,7 +48,7 @@ gesture_labels[3] = ['Flexion Of The Little Finger', 'Flexion Of The Ring Finger
 partial_gesture_labels = ['Rest', 'Finger Abduction', 'Fist', 'Finger Adduction', 'Middle Axis Supination', 
                           'Middle Axis Pronation', 'Wrist Flexion', 'Wrist Extension', 'Radial Deviation', 'Ulnar Deviation']
 partial_gesture_indices = [0] + [gesture_labels[1].index(g) + len(gesture_labels['Rest']) for g in partial_gesture_labels[1:]] # 0 is for rest
-label_to_index = {label: index for index, label in enumerate(partial_gesture_indices)}
+transition_labels = ['Not a Transition', 'Transition'] 
 class CustomDataset_swav(Dataset):
     def __init__(self, data, labels=None, transform=None):
         self.data = data
@@ -133,7 +133,7 @@ def seed_worker(worker_id):
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 
-def balance(restimulus, args):
+def balance_gesture_classifier(restimulus, args):
     """ Balances distribution of restimulus by minimizing zero (rest) gestures.
 
     Args:
@@ -165,8 +165,6 @@ def balance(restimulus, args):
                 else:
                     count_dict[elements] = 1
                 
- 
-    
     # Calculate average count of non-zero elements
     non_zero_counts = [count for key, count in count_dict.items() if key != (0,)]
     if non_zero_counts:
@@ -184,24 +182,71 @@ def balance(restimulus, args):
                 numZero += 1 # Rest always in partial
             else:
                 indices.append(x)
-                # if args.partial_dataset_ninapro:
-                #     if gesture in partial_gesture_indices:
-                #         indices.append(x)
-                # else: 
-                #     indices.append(x)
         else:
             if args.include_transitions:
                 indices.append(x)
-                # if args.partial_dataset_ninapro:
-                #     start_gesture = restimulus[x][0][0].item()
-                #     end_gesture = restimulus[x][0][-1].item()
-                #     if start_gesture in partial_gesture_indices and end_gesture in partial_gesture_indices:
-                #         indices.append(x)
-                # else:
-                #     indices.append(x)
-                
     return indices
 
+def balance_transition_classifier(restimulus, args):
+    '''
+    Balances such that there is an equal number of windows for all types of gestures. Balances all combinations of (start_gesture, end_gesture) windows not just between transition and non transition. 
+    '''
+    indices = []
+
+    transition_total = 0 
+    non_transition_total = 0 
+
+    transition_seen = {}
+    non_transition_seen = {}
+    
+    # First pass to count the number of each type of window
+    for x in range(len(restimulus)):
+
+        start_gesture = restimulus[x][0][0].item()
+        end_gesture = restimulus[x][0][-1].item()
+        gesture = (start_gesture, end_gesture)
+
+        if start_gesture == end_gesture: 
+            non_transition_seen[gesture] = non_transition_seen.get(gesture, 0) + 1
+            non_transition_total += 1
+
+        else: 
+            transition_seen[gesture] = transition_seen.get(gesture, 0) + 1
+            transition_total += 1
+
+    # Calculate average count of each gesture 
+    equal_threshold = min(transition_total, non_transition_total)
+    equal_transition_threshold = equal_threshold // len(transition_seen)
+    equal_non_transition_threshold = equal_threshold // len(non_transition_seen)
+
+    non_transition_windows_left = {key: equal_non_transition_threshold for key in non_transition_seen}
+    transition_windows_left = {key: equal_transition_threshold for key in transition_seen}
+
+    # Second pass: Add transtion/non-transition windows balanced per gesture.
+    for x in range(len(restimulus)):
+
+        start_gesture = restimulus[x][0][0].item()
+        end_gesture = restimulus[x][0][-1].item()
+        gesture = (start_gesture, end_gesture)
+
+        if start_gesture == end_gesture:
+            
+            if non_transition_windows_left[gesture] > 0: 
+                indices.append(x)
+                non_transition_windows_left[gesture] -= 1
+        
+        else:
+            if transition_windows_left[gesture] > 0:
+                indices.append(x)
+                transition_windows_left[gesture] -= 1
+
+    return indices
+
+def balance(restimulus, args):
+    if args.transition_classifier:
+        return balance_transition_classifier(restimulus, args)
+    else:
+        return balance_gesture_classifier(restimulus, args)
 
 def contract(restim, args):
     if args.transition_classifier:
@@ -230,12 +275,6 @@ def contract_gesture_classifier(restim, args):
             gesture = int(restim[x][0][-1]) # take the last gesture it belongs to (labels the transition as part of the gesture)
         else:
             gesture = int(restim[x][0][0])
-
-        # if args.partial_dataset_ninapro:
-        #     labels[x][label_to_index[gesture]] = 1.0
-        # else:
-        #     labels[x][gesture] = 1.0
-
         labels[x][gesture] = 1.0
     
     return labels
@@ -260,6 +299,7 @@ def contract_transition_classifier(restim, args):
         transition_labels[x] = torch.tensor([start_gesture, end_gesture], dtype=torch.float32)
 
     return transition_labels
+
 
 def filter(emg):
     # sixth-order Butterworth highpass filter

--- a/Setup/Utils/utils_NinaproDB2.py
+++ b/Setup/Utils/utils_NinaproDB2.py
@@ -183,20 +183,22 @@ def balance(restimulus, args):
                     indices.append(x)
                 numZero += 1 # Rest always in partial
             else:
-                if args.partial_dataset_ninapro:
-                    if gesture in partial_gesture_indices:
-                        indices.append(x)
-                else: 
-                    indices.append(x)
+                indices.append(x)
+                # if args.partial_dataset_ninapro:
+                #     if gesture in partial_gesture_indices:
+                #         indices.append(x)
+                # else: 
+                #     indices.append(x)
         else:
             if args.include_transitions:
-                if args.partial_dataset_ninapro:
-                    start_gesture = restimulus[x][0][0].item()
-                    end_gesture = restimulus[x][0][-1].item()
-                    if start_gesture in partial_gesture_indices and end_gesture in partial_gesture_indices:
-                        indices.append(x)
-                else:
-                    indices.append(x)
+                indices.append(x)
+                # if args.partial_dataset_ninapro:
+                #     start_gesture = restimulus[x][0][0].item()
+                #     end_gesture = restimulus[x][0][-1].item()
+                #     if start_gesture in partial_gesture_indices and end_gesture in partial_gesture_indices:
+                #         indices.append(x)
+                # else:
+                #     indices.append(x)
                 
     return indices
 
@@ -229,10 +231,12 @@ def contract_gesture_classifier(restim, args):
         else:
             gesture = int(restim[x][0][0])
 
-        if args.partial_dataset_ninapro:
-            labels[x][label_to_index[gesture]] = 1.0
-        else:
-            labels[x][gesture] = 1.0
+        # if args.partial_dataset_ninapro:
+        #     labels[x][label_to_index[gesture]] = 1.0
+        # else:
+        #     labels[x][gesture] = 1.0
+
+        labels[x][gesture] = 1.0
     
     return labels
 
@@ -246,18 +250,16 @@ def contract_transition_classifier(restim, args):
     Returns:
         labels: restimulus data now one-hot encoded
     """
-
-    labels = torch.tensor(())
-    labels = labels.new_zeros(size=(len(restim), 2))
+    transition_labels = torch.zeros((len(restim), 2), dtype=torch.float32)
 
     for x in range(len(restim)):
 
-        if restim[x][0][0].item() == restim[x][0][-1].item():
-            labels[x][0] = 1.0
-        else:
-            labels[x][1] = 1.0
-    
-    return labels
+        start_gesture = restim[x][0][0].item()
+        end_gesture = restim[x][0][-1].item()
+
+        transition_labels[x] = torch.tensor([start_gesture, end_gesture], dtype=torch.float32)
+
+    return transition_labels
 
 def filter(emg):
     # sixth-order Butterworth highpass filter

--- a/Setup/Utils/utils_NinaproDB3.py
+++ b/Setup/Utils/utils_NinaproDB3.py
@@ -50,6 +50,14 @@ gesture_labels[3] = ['Flexion Of The Little Finger', 'Flexion Of The Ring Finger
 partial_gesture_labels = ['Rest', 'Finger Abduction', 'Fist', 'Finger Adduction', 'Middle Axis Supination', 
                           'Middle Axis Pronation', 'Wrist Flexion', 'Wrist Extension', 'Radial Deviation', 'Ulnar Deviation']
 partial_gesture_indices = [0] + [gesture_labels[1].index(g) + len(gesture_labels['Rest']) for g in partial_gesture_labels[1:]] # 0 is for rest
+
+
+label_to_index = {label: index for index, label in enumerate(partial_gesture_indices)}
+transition_labels = ['Not a Transition', 'Transition']
+
+
+
+
 class CustomDataset_swav(Dataset):
     def __init__(self, data, labels=None, transform=None):
         self.data = data
@@ -161,7 +169,6 @@ def balance(restimulus, args):
             if args.include_transitions:
                 elements = (restimulus[x][0][0].item(), restimulus[x][0][-1].item()) # take first and last gesture (transition window)
 
-                # elements = int(str(restimulus[x][0][0].item()) + str(restimulus[x][0][-1].item())) # TODO: Figure out why dict keys have to be ints. Making them tuples or strings leads to different dimensions for X and Y for some reason. This is a hacky way to get around it. 
                 if elements in count_dict:
                     count_dict[elements] += 1
                 else:
@@ -176,23 +183,41 @@ def balance(restimulus, args):
     else:
         avg_count = 0  # Handle case where there are no non-zero unique elements
 
-    # Second pass: apply the threshold logic
     for x in range(len(restimulus)):
         unique_elements = torch.unique(restimulus[x])
         if len(unique_elements) == 1:
-            if unique_elements.item() == 0:
+            gesture = unique_elements.item()
+            if gesture == 0: 
                 if numZero < avg_count:
                     indices.append(x)
-                numZero += 1
+                numZero += 1 # Rest always in partial
             else:
-                indices.append(x)
+                if args.partial_dataset_ninapro:
+                    if gesture in partial_gesture_indices:
+                        indices.append(x)
+                else: 
+                    indices.append(x)
         else:
             if args.include_transitions:
-                indices.append(x)
+                if args.partial_dataset_ninapro:
+                    start_gesture = restimulus[x][0][0].item()
+                    end_gesture = restimulus[x][0][-1].item()
+                    if start_gesture in partial_gesture_indices and end_gesture in partial_gesture_indices:
+                        indices.append(x)
+                else:
+                    indices.append(x)
                 
     return indices
 
+
+
 def contract(restim, args):
+    if args.transition_classifier:
+        return contract_transition_classifier(restim, args)
+    else:
+        return contract_gesture_classifier(restim, args)
+
+def contract_gesture_classifier(restim, args):
     """Converts restimulus tensor to one-hot encoded tensor.
 
     Args:
@@ -204,19 +229,46 @@ def contract(restim, args):
     """
     numGestures = restim.max() + 1 # + 1 to account for rest gesture
     labels = torch.tensor(())
-    labels = labels.new_zeros(size=(len(restim), numGestures))
-  
-    for x in range(len(restim)):
 
+
+    labels = labels.new_zeros(size=(len(restim), numGestures))
+
+    for x in range(len(restim)):
         if args.include_transitions:
             gesture = int(restim[x][0][-1]) # take the last gesture it belongs to (labels the transition as part of the gesture)
         else:
             gesture = int(restim[x][0][0])
-            
-        gesture = make_gesture_sequential(gesture, args)
-        labels[x][gesture] = 1.0
+
+        if args.partial_dataset_ninapro:
+            labels[x][label_to_index[gesture]] = 1.0
+        else:
+            labels[x][gesture] = 1.0
     
     return labels
+
+def contract_transition_classifier(restim, args):
+    """Converts restimulus tensor to one-hot encoded tensor.
+
+    Args:
+        restim (tensor): restimulus data tensor
+        unfold (bool, optional): whether data was unfolded according to time steps. Defaults to True.
+
+    Returns:
+        labels: restimulus data now one-hot encoded
+    """
+
+    labels = torch.tensor(())
+    labels = labels.new_zeros(size=(len(restim), 2))
+
+    for x in range(len(restim)):
+
+        if restim[x][0][0].item() == restim[x][0][-1].item():
+            labels[x][0] = 1.0
+        else:
+            labels[x][1] = 1.0
+    
+    return labels
+
 
 def filter(emg):
     # sixth-order Butterworth highpass filter

--- a/Setup/Utils/utils_UCI.py
+++ b/Setup/Utils/utils_UCI.py
@@ -102,7 +102,6 @@ def balance_transition_classifier (restimulus):
 
     transition_total = 0
     non_transition_total = 0 
-    gestures_added = {}
     non_transition_seen = {}
     transition_seen = {}
 
@@ -123,7 +122,6 @@ def balance_transition_classifier (restimulus):
                 transition_total += 1
 
     equal_threshold = min(transition_total, non_transition_total)
-
     equal_transition_threshold = equal_threshold // len(transition_seen)
     equal_non_transition_threshold = equal_threshold // len(non_transition_seen)
 
@@ -140,7 +138,6 @@ def balance_transition_classifier (restimulus):
            
             if start_gesture >= 0 and start_gesture <= 6: 
                 if non_transition_windows_left[gesture] > 0:
-                    gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
                     indices.append(x)
                     non_transition_windows_left[gesture] -= 1
 
@@ -151,11 +148,9 @@ def balance_transition_classifier (restimulus):
         
             if end_gesture >= 0 and end_gesture <= 6:
                 if transition_windows_left[gesture] > 0:
-                    gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
                     indices.append(x)
                     transition_windows_left[gesture] -= 1
-        
-    # print("non-seq balanced gesture_count", gestures_added, "sum:", sum(gestures_added.values()), "unique gestures", np.unique(restimulus)-1)
+
     return indices
 
 
@@ -209,10 +204,9 @@ def contract(R, unfold=True):
 
 def label_transition(R, unfold=True):
     '''
-    Should return a tensor of shape (N, 2) where per window each row represents the (start, end) of a transition.
+    Should return a tensor of shape (N, 2) where per window we label [start_gesture, end_gesture] of a transition.
     '''
 
-    # Initialize the tensor with zeros
     transition_labels = torch.zeros((len(R), 2), dtype=torch.float32)
 
     # Populate the tensor with (start, end) pairs
@@ -223,9 +217,6 @@ def label_transition(R, unfold=True):
         transition_labels[x] = torch.tensor([start_gesture, end_gesture], dtype=torch.float32)
     
     return transition_labels
-
-
-
 
 def filter(emg):
     # sixth-order Butterworth highpass filter

--- a/Setup/Utils/utils_UCI.py
+++ b/Setup/Utils/utils_UCI.py
@@ -32,8 +32,11 @@ cmap = mpl.colormaps['viridis']
 # Gesture Labels
 gesture_labels = ["hand at rest","hand clenched in a fist","wrist flexion","wrist extension","radial deviations","ulnar deviations","extended palm"]
 gesture_labels = gesture_labels[:numGestures]
+transition_labels = ['Not a Transition', 'Transition']
 
 include_transitions = False # Whether or not to include mixed gestures and label them as their last. Defined by Setup/Setup.py
+args = None # Defined by Setup/Setup.py
+
 
 class CustomDataset(Dataset):
     def __init__(self, data, labels, transform=None):
@@ -68,7 +71,7 @@ def seed_worker(worker_id):
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 
-def balance (restimulus):
+def balance_gesture_classifier (restimulus):
     indices = []
     for x in range (len(restimulus)):
         unique_gestures = len(torch.unique(restimulus[x]))
@@ -89,7 +92,66 @@ def balance (restimulus):
           
     return indices
 
-def contract(R, unfold=True):
+def balance_transition_classifier (restimulus):
+    indices = []
+
+
+    # First pass: count the occurences of each type of window
+
+    transition_limit = 0
+    non_transition_limit = 0 
+
+    for x in range (len(restimulus)):
+
+        start_gesture = int(restimulus[x][0])-1
+        end_gesture = int(restimulus[x][-1])-1
+
+        if start_gesture == end_gesture:
+            non_transition_limit += 1
+        else:
+            if end_gesture >= 0 and end_gesture <= 6:
+                transition_limit += 1
+
+    
+    equal_threshold = min(transition_limit, non_transition_limit)
+    non_transition_count = 0
+    transition_count = 0 
+
+    for x in range (len(restimulus)):
+        unique_gestures = len(torch.unique(restimulus[x]))
+        if unique_gestures == 1: 
+            gesture = restimulus[x][0] - 1 # 0 is unmarked data, 1 rest, etc
+            if gesture >= 0 and gesture <= 6: 
+
+                if non_transition_count < equal_threshold:
+                    indices.append(x)
+                    non_transition_count += 1
+
+        else: 
+          
+            start_gesture = restimulus[x][0] - 1
+            end_gesture = restimulus[x][-1] - 1 
+        
+            if end_gesture >= 0 and end_gesture <= 6:
+                if transition_count < equal_threshold:
+                    indices.append(x)
+                    transition_count += 1
+        
+                
+
+          
+    return indices
+
+
+def balance(restimulus):
+    
+    if args.transition_classifier:
+        return balance_transition_classifier(restimulus)
+    else:
+        return balance_gesture_classifier(restimulus)
+
+
+def contract_gesture_classifer(R, unfold=True):
     labels = torch.tensor(())
     labels = labels.new_zeros(size=(len(R), numGestures))
     if (unfold):
@@ -103,6 +165,34 @@ def contract(R, unfold=True):
         for x in range(len(R)):
             labels[x][int(R[x]) - 1] = 1.0
     return labels
+
+
+def contract_transition_classifier(R):
+
+    labels = torch.tensor(())
+    labels = labels.new_zeros(size=(len(R), 2))
+    for x in range(len(R)):
+
+        start_gesture = int(R[x][0]) - 1
+        end_gesture = int(R[x][-1]) - 1
+
+        if start_gesture == end_gesture:
+            labels[x][0] = 1.0
+        else:
+            labels[x][1] = 1.0
+   
+    return labels
+
+def contract(R, unfold=True):
+
+    if args.transition_classifier:
+        assert unfold == True, "Cannot do gesture classification without contracting."
+        return contract_transition_classifier(R)
+    else:
+        
+        return contract_gesture_classifer(R, unfold)
+
+
 
 def filter(emg):
     # sixth-order Butterworth highpass filter
@@ -592,6 +682,7 @@ def plot_average_images(image_data, true, gesture_labels, testrun_foldername, ar
     # Calculate average image of each gesture
     average_images = []
     print(f"Plotting average {partition_name} images...")
+    numGestures = len(gesture_labels)
     for i in range(numGestures):
         # Find indices
         gesture_indices = np.where(true_np == i)[0]
@@ -623,7 +714,7 @@ def plot_first_fifteen_images(image_data, true, gesture_labels, testrun_folderna
 
     # Parameters for plotting
     rows_per_gesture = 15
-    total_gestures = numGestures  # Replace with the actual number of gestures
+    total_gestures = len(gesture_labels)  # Replace with the actual number of gestures
 
     # Create subplots
     fig, axs = plt.subplots(rows_per_gesture, total_gestures, figsize=(20, 20))

--- a/Setup/Utils/utils_UCI.py
+++ b/Setup/Utils/utils_UCI.py
@@ -71,6 +71,7 @@ def seed_worker(worker_id):
     np.random.seed(worker_seed)
     random.seed(worker_seed)
 
+
 def balance_gesture_classifier (restimulus):
     indices = []
     for x in range (len(restimulus)):
@@ -92,40 +93,194 @@ def balance_gesture_classifier (restimulus):
           
     return indices
 
+
+# per gesture
+# def balance_transition_classifier (restimulus):
+    
+#     indices = []
+#     default_indices = []
+
+#     non_transition_total = 0
+#     transition_total = 0 
+#     non_transition_count = {}
+#     transition_count = {} 
+
+#     for x in range(len(restimulus)):
+
+#         start_gesture = int(restimulus[x][0]) - 1
+#         end_gesture = int(restimulus[x][-1]) - 1
+
+#         gesture = (start_gesture, end_gesture)
+        
+#         if start_gesture == end_gesture:
+
+#             assert(len(np.unique(restimulus[x])) == 1)
+            
+#             if 0 <= start_gesture and start_gesture <= 6: 
+#                 non_transition_total += 1 
+#                 non_transition_count[gesture] = non_transition_count.get(gesture, 0) + 1
+
+#         else:
+
+#             if 0 <= end_gesture and end_gesture <= 6:
+#                 transition_total += 1
+#                 transition_count[gesture] = transition_count.get(gesture, 0) + 1
+
+#     equal_threshold = min(transition_total, non_transition_total)
+#     non_transition_avg = equal_threshold // len(non_transition_count)
+#     transition_avg = equal_threshold // len(transition_count)
+
+#     non_transition_windows = {key: non_transition_avg for key in non_transition_count}
+#     transition_windows = {key: transition_avg for key in transition_count}
+
+
+#     gesture_count = {}
+
+#     for x in range(len(restimulus)):
+
+#         start_gesture = int(restimulus[x][0]) - 1
+#         end_gesture = int(restimulus[x][-1]) - 1
+
+#         gesture = (start_gesture, end_gesture)
+
+#         if start_gesture == end_gesture:
+#             assert(len(np.unique(restimulus[x])) == 1)
+#             if 0 <= start_gesture and start_gesture <= 6: 
+#                 if non_transition_windows[gesture] > 0:
+#                     gesture_count[gesture] = gesture_count.get(gesture, 0) + 1
+#                     indices.append(x)
+#                     non_transition_windows[gesture] -= 1
+
+#         else: 
+#             if 0 <= end_gesture and end_gesture <= 6:
+#                 if transition_windows[gesture] > 0:
+#                     gesture_count[gesture] = gesture_count.get(gesture, 0) + 1
+#                     indices.append(x)
+#                     transition_windows[gesture] -= 1
+    
+#     print("gesture_count", gesture_count, "sum:", sum(gesture_count.values()))
+
+
+#     return indices
+
+# SEQUENTIAL
+# def balance_transition_classifier (restimulus):
+#     indices = []
+
+#     # First pass: count the occurences of each type of window
+
+#     transition_total = 0
+#     non_transition_total = 0 
+
+#     gestures_added = {}
+
+
+#     for x in range (len(restimulus)):
+
+#         start_gesture = int(restimulus[x][0])-1
+#         end_gesture = int(restimulus[x][-1])-1
+        
+
+#         if start_gesture == end_gesture:
+#             if start_gesture >= 0 and start_gesture <= 6:
+#                 non_transition_total += 1
+#         else:
+#             if end_gesture >= 0 and end_gesture <= 6:
+#                 transition_total += 1
+
+#     equal_threshold = min(transition_total, non_transition_total)
+#     non_transition_count = 0
+#     transition_count = 0 
+
+    
+
+#     for x in range (len(restimulus)):
+
+#         start_gesture = int(restimulus[x][0])-1
+#         end_gesture = int(restimulus[x][-1])-1
+#         gesture = (start_gesture, end_gesture)
+
+#         if start_gesture == end_gesture:
+           
+#             if start_gesture >= 0 and start_gesture <= 6: 
+#                 if non_transition_count < equal_threshold:
+#                     gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
+#                     indices.append(x)
+#                     non_transition_count += 1
+
+#         else: 
+          
+#             start_gesture = restimulus[x][0] - 1
+#             end_gesture = restimulus[x][-1] - 1 
+        
+#             if end_gesture >= 0 and end_gesture <= 6:
+#                 if transition_count < equal_threshold:
+#                     gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
+#                     indices.append(x)
+#                     transition_count += 1
+        
+#     print("gesture_count", gestures_added, "sum:", sum(gestures_added.values()), "unique gestures", np.unique(restimulus)-1)
+#     return indices
+
+
 def balance_transition_classifier (restimulus):
     indices = []
 
-
     # First pass: count the occurences of each type of window
 
-    transition_limit = 0
-    non_transition_limit = 0 
+    transition_total = 0
+    non_transition_total = 0 
+
+
+
+    gestures_added = {}
+    non_transition_seen = {}
+    transition_seen = {}
+
 
     for x in range (len(restimulus)):
 
         start_gesture = int(restimulus[x][0])-1
         end_gesture = int(restimulus[x][-1])-1
 
+        gesture = (start_gesture, end_gesture)
+        
+
         if start_gesture == end_gesture:
-            non_transition_limit += 1
+            if start_gesture >= 0 and start_gesture <= 6:
+                non_transition_seen[gesture] = non_transition_seen.get(gesture, 0) + 1
+                non_transition_total += 1
         else:
             if end_gesture >= 0 and end_gesture <= 6:
-                transition_limit += 1
+                transition_seen[gesture] = transition_seen.get(gesture, 0) + 1
+                transition_total += 1
 
-    
-    equal_threshold = min(transition_limit, non_transition_limit)
+    equal_threshold = min(transition_total, non_transition_total)
+
+    equal_transition_threshold = equal_threshold // len(transition_seen)
+    equal_non_transition_threshold = equal_threshold // len(non_transition_seen)
+
+    non_transition_windows = {key: equal_non_transition_threshold for key in non_transition_seen}
+    transition_windows = {key: equal_transition_threshold for key in transition_seen}
+
     non_transition_count = 0
     transition_count = 0 
 
     for x in range (len(restimulus)):
-        unique_gestures = len(torch.unique(restimulus[x]))
-        if unique_gestures == 1: 
-            gesture = restimulus[x][0] - 1 # 0 is unmarked data, 1 rest, etc
-            if gesture >= 0 and gesture <= 6: 
 
-                if non_transition_count < equal_threshold:
+        start_gesture = int(restimulus[x][0])-1
+        end_gesture = int(restimulus[x][-1])-1
+        gesture = (start_gesture, end_gesture)
+
+        if start_gesture == end_gesture:
+           
+            if start_gesture >= 0 and start_gesture <= 6: 
+                # if non_transition_count < equal_threshold:
+                if non_transition_windows[gesture] > 0:
+                    gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
                     indices.append(x)
-                    non_transition_count += 1
+                    # non_transition_count += 1
+                    non_transition_windows[gesture] -= 1
 
         else: 
           
@@ -133,13 +288,14 @@ def balance_transition_classifier (restimulus):
             end_gesture = restimulus[x][-1] - 1 
         
             if end_gesture >= 0 and end_gesture <= 6:
-                if transition_count < equal_threshold:
+                # if transition_count < equal_threshold:
+                if transition_windows[gesture] > 0:
+                    gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
                     indices.append(x)
-                    transition_count += 1
+                    # transition_count += 1
+                    transition_windows[gesture] -= 1
         
-                
-
-          
+    print("non-seq balanced gesture_count", gestures_added, "sum:", sum(gestures_added.values()), "unique gestures", np.unique(restimulus)-1)
     return indices
 
 
@@ -713,11 +869,19 @@ def plot_first_fifteen_images(image_data, true, gesture_labels, testrun_folderna
     true_np = np.array(true)
 
     # Parameters for plotting
-    rows_per_gesture = 15
-    total_gestures = len(gesture_labels)  # Replace with the actual number of gestures
+    # rows_per_gesture = 15
+    # total_gestures = len(gesture_labels)  # Replace with the actual number of gestures
+
+
+    if args.transition_classifier:
+        rows_per_gesture = 30
+        total_gestures = 2
+    else: 
+        total_gestures = numGestures
+        rows_per_gesture = 15
 
     # Create subplots
-    fig, axs = plt.subplots(rows_per_gesture, total_gestures, figsize=(20, 20))
+    fig, axs = plt.subplots(rows_per_gesture, total_gestures, figsize=(40, 40))
 
     print(f"Plotting first fifteen {partition_name} images...")
     for i in range(total_gestures):

--- a/Setup/Utils/utils_UCI.py
+++ b/Setup/Utils/utils_UCI.py
@@ -94,134 +94,6 @@ def balance_gesture_classifier (restimulus):
     return indices
 
 
-# per gesture
-# def balance_transition_classifier (restimulus):
-    
-#     indices = []
-#     default_indices = []
-
-#     non_transition_total = 0
-#     transition_total = 0 
-#     non_transition_count = {}
-#     transition_count = {} 
-
-#     for x in range(len(restimulus)):
-
-#         start_gesture = int(restimulus[x][0]) - 1
-#         end_gesture = int(restimulus[x][-1]) - 1
-
-#         gesture = (start_gesture, end_gesture)
-        
-#         if start_gesture == end_gesture:
-
-#             assert(len(np.unique(restimulus[x])) == 1)
-            
-#             if 0 <= start_gesture and start_gesture <= 6: 
-#                 non_transition_total += 1 
-#                 non_transition_count[gesture] = non_transition_count.get(gesture, 0) + 1
-
-#         else:
-
-#             if 0 <= end_gesture and end_gesture <= 6:
-#                 transition_total += 1
-#                 transition_count[gesture] = transition_count.get(gesture, 0) + 1
-
-#     equal_threshold = min(transition_total, non_transition_total)
-#     non_transition_avg = equal_threshold // len(non_transition_count)
-#     transition_avg = equal_threshold // len(transition_count)
-
-#     non_transition_windows = {key: non_transition_avg for key in non_transition_count}
-#     transition_windows = {key: transition_avg for key in transition_count}
-
-
-#     gesture_count = {}
-
-#     for x in range(len(restimulus)):
-
-#         start_gesture = int(restimulus[x][0]) - 1
-#         end_gesture = int(restimulus[x][-1]) - 1
-
-#         gesture = (start_gesture, end_gesture)
-
-#         if start_gesture == end_gesture:
-#             assert(len(np.unique(restimulus[x])) == 1)
-#             if 0 <= start_gesture and start_gesture <= 6: 
-#                 if non_transition_windows[gesture] > 0:
-#                     gesture_count[gesture] = gesture_count.get(gesture, 0) + 1
-#                     indices.append(x)
-#                     non_transition_windows[gesture] -= 1
-
-#         else: 
-#             if 0 <= end_gesture and end_gesture <= 6:
-#                 if transition_windows[gesture] > 0:
-#                     gesture_count[gesture] = gesture_count.get(gesture, 0) + 1
-#                     indices.append(x)
-#                     transition_windows[gesture] -= 1
-    
-#     print("gesture_count", gesture_count, "sum:", sum(gesture_count.values()))
-
-
-#     return indices
-
-# SEQUENTIAL
-# def balance_transition_classifier (restimulus):
-#     indices = []
-
-#     # First pass: count the occurences of each type of window
-
-#     transition_total = 0
-#     non_transition_total = 0 
-
-#     gestures_added = {}
-
-
-#     for x in range (len(restimulus)):
-
-#         start_gesture = int(restimulus[x][0])-1
-#         end_gesture = int(restimulus[x][-1])-1
-        
-
-#         if start_gesture == end_gesture:
-#             if start_gesture >= 0 and start_gesture <= 6:
-#                 non_transition_total += 1
-#         else:
-#             if end_gesture >= 0 and end_gesture <= 6:
-#                 transition_total += 1
-
-#     equal_threshold = min(transition_total, non_transition_total)
-#     non_transition_count = 0
-#     transition_count = 0 
-
-    
-
-#     for x in range (len(restimulus)):
-
-#         start_gesture = int(restimulus[x][0])-1
-#         end_gesture = int(restimulus[x][-1])-1
-#         gesture = (start_gesture, end_gesture)
-
-#         if start_gesture == end_gesture:
-           
-#             if start_gesture >= 0 and start_gesture <= 6: 
-#                 if non_transition_count < equal_threshold:
-#                     gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
-#                     indices.append(x)
-#                     non_transition_count += 1
-
-#         else: 
-          
-#             start_gesture = restimulus[x][0] - 1
-#             end_gesture = restimulus[x][-1] - 1 
-        
-#             if end_gesture >= 0 and end_gesture <= 6:
-#                 if transition_count < equal_threshold:
-#                     gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
-#                     indices.append(x)
-#                     transition_count += 1
-        
-#     print("gesture_count", gestures_added, "sum:", sum(gestures_added.values()), "unique gestures", np.unique(restimulus)-1)
-#     return indices
-
 
 def balance_transition_classifier (restimulus):
     indices = []
@@ -230,13 +102,9 @@ def balance_transition_classifier (restimulus):
 
     transition_total = 0
     non_transition_total = 0 
-
-
-
     gestures_added = {}
     non_transition_seen = {}
     transition_seen = {}
-
 
     for x in range (len(restimulus)):
 
@@ -245,7 +113,6 @@ def balance_transition_classifier (restimulus):
 
         gesture = (start_gesture, end_gesture)
         
-
         if start_gesture == end_gesture:
             if start_gesture >= 0 and start_gesture <= 6:
                 non_transition_seen[gesture] = non_transition_seen.get(gesture, 0) + 1
@@ -260,11 +127,8 @@ def balance_transition_classifier (restimulus):
     equal_transition_threshold = equal_threshold // len(transition_seen)
     equal_non_transition_threshold = equal_threshold // len(non_transition_seen)
 
-    non_transition_windows = {key: equal_non_transition_threshold for key in non_transition_seen}
-    transition_windows = {key: equal_transition_threshold for key in transition_seen}
-
-    non_transition_count = 0
-    transition_count = 0 
+    non_transition_windows_left = {key: equal_non_transition_threshold for key in non_transition_seen}
+    transition_windows_left = {key: equal_transition_threshold for key in transition_seen}
 
     for x in range (len(restimulus)):
 
@@ -275,12 +139,10 @@ def balance_transition_classifier (restimulus):
         if start_gesture == end_gesture:
            
             if start_gesture >= 0 and start_gesture <= 6: 
-                # if non_transition_count < equal_threshold:
-                if non_transition_windows[gesture] > 0:
+                if non_transition_windows_left[gesture] > 0:
                     gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
                     indices.append(x)
-                    # non_transition_count += 1
-                    non_transition_windows[gesture] -= 1
+                    non_transition_windows_left[gesture] -= 1
 
         else: 
           
@@ -288,14 +150,12 @@ def balance_transition_classifier (restimulus):
             end_gesture = restimulus[x][-1] - 1 
         
             if end_gesture >= 0 and end_gesture <= 6:
-                # if transition_count < equal_threshold:
-                if transition_windows[gesture] > 0:
+                if transition_windows_left[gesture] > 0:
                     gestures_added[gesture] = gestures_added.get(gesture, 0) + 1
                     indices.append(x)
-                    # transition_count += 1
-                    transition_windows[gesture] -= 1
+                    transition_windows_left[gesture] -= 1
         
-    print("non-seq balanced gesture_count", gestures_added, "sum:", sum(gestures_added.values()), "unique gestures", np.unique(restimulus)-1)
+    # print("non-seq balanced gesture_count", gestures_added, "sum:", sum(gestures_added.values()), "unique gestures", np.unique(restimulus)-1)
     return indices
 
 
@@ -345,8 +205,25 @@ def contract(R, unfold=True):
         assert unfold == True, "Cannot do gesture classification without contracting."
         return contract_transition_classifier(R)
     else:
-        
         return contract_gesture_classifer(R, unfold)
+
+def label_transition(R, unfold=True):
+    '''
+    Should return a tensor of shape (N, 2) where per window each row represents the (start, end) of a transition.
+    '''
+
+    # Initialize the tensor with zeros
+    transition_labels = torch.zeros((len(R), 2), dtype=torch.float32)
+
+    # Populate the tensor with (start, end) pairs
+    for x in range(len(R)):
+        start_gesture = int(R[x][0]) - 1
+        end_gesture = int(R[x][-1]) - 1
+
+        transition_labels[x] = torch.tensor([start_gesture, end_gesture], dtype=torch.float32)
+    
+    return transition_labels
+
 
 
 
@@ -539,11 +416,18 @@ def getRestim_separateSessions(args, unfold=True):
     return torch.cat(restim, dim=0)
 
 def getLabels (n, unfold=True):
-    return contract(getRestim(n, unfold), unfold)
+
+    if args.transition_classifier:
+        return label_transition(getRestim(n, unfold), unfold)
+    else:
+        return contract(getRestim(n, unfold), unfold)
 
 def getLabels_separateSessions(args, unfold=True):
     subject_number, session_number = args
     return contract(getRestim_separateSessions((subject_number, session_number), unfold), unfold)
+
+
+
 
 def closest_factors(num):
     # Find factors of the number

--- a/Split_Strategies/Data_Split_Strategy.py
+++ b/Split_Strategies/Data_Split_Strategy.py
@@ -4,6 +4,7 @@ Data_Split_Strategy.py
 - Acts as a wrapper for X, Y, and label objects. Repeats function calls for each object.
 """
 from .cross_validation_utilities import train_test_split as tts # custom train test split to split stratified without shuffling
+import torch 
 class Data_Split_Strategy():
     """
     Base strategy. Serves as a wrapper to hold X, Y, and label objects. 
@@ -19,8 +20,6 @@ class Data_Split_Strategy():
         self.Y = Y_data
         self.label = label_data
         
-        
-
     def split(self):
         raise NotImplementedError("Subclasses must implement split()")
     
@@ -71,6 +70,7 @@ class Data_Split_Strategy():
 
     def test_from_validation(self):
         
+        # TRAIN 
         self.X.test, self.X.validation, \
         self.Y.test, self.Y.validation, \
         self.label.test, self.label.validation \
@@ -81,11 +81,19 @@ class Data_Split_Strategy():
             stratify=self.label.validation,
             random_state=self.args.seed,
             shuffle=(not self.args.train_test_split_for_time_series),
-            force_regression=self.args.force_regression
+            force_regression=self.args.force_regression,
+            transition_classifier=self.args.transition_classifier
         )
 
     def all_sets_to_tensor(self):
         self.X.all_sets_to_tensor()
         self.Y.all_sets_to_tensor()
         self.label.all_sets_to_tensor()
-   
+
+    def contract_to_binary_gestures(self):
+        '''
+        Convert from labels of the type [start, end] to [0] or [1] depending on whether or not they are a gesture. 
+        '''
+
+        self.Y.transition_labels_to_binary()
+        self.label.transition_labels_to_binary()

--- a/Split_Strategies/Leave_One_Session_Out.py
+++ b/Split_Strategies/Leave_One_Session_Out.py
@@ -80,7 +80,8 @@ class Leave_One_Session_Out(Data_Split_Strategy):
                 stratify=label_train_temp, 
                 random_state=self.args.seed, 
                 shuffle=(not self.args.train_test_split_for_time_series),
-                force_regression=self.args.force_regression
+                force_regression=self.args.force_regression, 
+                transition_classifier=self.args.transition_classifier
             )
             
         if self.args.proportion_unlabeled_data_from_training_subjects>0 and self.args.turn_on_unlabeled_domain_adaptation:
@@ -94,7 +95,8 @@ class Leave_One_Session_Out(Data_Split_Strategy):
                 stratify=label_train_temp, 
                 random_state=self.args.seed, 
                 shuffle=(not self.args.train_test_split_for_time_series),
-                force_regression=self.args.force_regression
+                force_regression=self.args.force_regression, 
+                transition_classifier=self.args.transition_classifier
             )
 
             self.append_to_pretrain(X_pretrain_labeled, Y_pretrain_labeled, label_pretrain_labeled)
@@ -134,7 +136,8 @@ class Leave_One_Session_Out(Data_Split_Strategy):
                 stratify=label_train_temp, 
                 random_state=self.args.seed, 
                 shuffle=(not self.args.train_test_split_for_time_series),
-                force_regression=self.args.force_regression
+                force_regression=self.args.force_regression, 
+                transition_classifier=self.args.transition_classifier
             )
 
             self.append_to_finetune(X_finetune_labeled, Y_finetune_labeled, label_finetune_labeled)

--- a/Split_Strategies/Single_Subject.py
+++ b/Split_Strategies/Single_Subject.py
@@ -27,7 +27,8 @@ class Single_Subject(Data_Split_Strategy):
             test_size=1-self.args.proportion_transfer_learning_from_leftout_subject, 
             stratify=self.label.train, 
             shuffle=(not self.args.train_test_split_for_time_series), 
-            force_regression=self.args.force_regression
+            force_regression=self.args.force_regression,
+            transition_classifier=self.args.transition_classifier
             )
 
         self.train_from_self_tensor()

--- a/Split_Strategies/cross_validation_utilities/train_test_split.py
+++ b/Split_Strategies/cross_validation_utilities/train_test_split.py
@@ -45,6 +45,7 @@ def train_test_split(
         train_size = train_size or 1 - test_size
 
         if transition_classifier:
+            # Labels are of type [start_gesture, end_gesture]
             
             transitions = [(int(start), int(end)) for start, end in Y_train_set_og]
             counter = Counter(transitions) 
@@ -73,8 +74,6 @@ def train_test_split(
             label_train_set = stratify.clone()
 
             unique, counts = np.unique(stratify, return_counts=True) # (GESTURE, ITS WINDOWS)
-
-       
 
         # split data for each class
         X_train = []

--- a/Split_Strategies/cross_validation_utilities/train_test_split.py
+++ b/Split_Strategies/cross_validation_utilities/train_test_split.py
@@ -1,5 +1,7 @@
 from sklearn import model_selection
 import numpy as np
+from collections import Counter
+import torch
 
 def train_test_split(
     *arrays,
@@ -8,7 +10,8 @@ def train_test_split(
     random_state=None,
     shuffle=True,
     stratify=None,
-    force_regression=False
+    force_regression=False, 
+    transition_classifier=False
 ): 
     """Splits data into training and testing sets. 
 
@@ -32,7 +35,7 @@ def train_test_split(
 
     if shuffle==False and stratify is not None:
         X_train_set = arrays[0]
-        Y_train_set_og = arrays[1]
+        Y_train_set_og = arrays[1] 
 
         if train_size is None and test_size is None:
             train_size = 0.75
@@ -41,23 +44,37 @@ def train_test_split(
 
         train_size = train_size or 1 - test_size
 
-        stratify_one_hot = False
-        is_y_one_hot = False
-        NUM_GESTURES = stratify.shape[1]
+        if transition_classifier:
+            
+            transitions = [(int(start), int(end)) for start, end in Y_train_set_og]
+            counter = Counter(transitions) 
+            unique, counts = counter.keys(), counter.values()
+            counts = np.array(list(counts))
 
-        # If labels are one-hot-encoded, convert to 1D array      
-        if stratify.shape[1] != 1:
-            stratify_one_hot = True
-            stratify = np.argmax(stratify, axis=1)
-        if not force_regression and Y_train_set_og.shape[1] != 1:
-            is_y_one_hot = True
-            Y_train_set = np.argmax(Y_train_set_og, axis=1)
-        else:
             Y_train_set = Y_train_set_og
+            label_train_set = stratify.clone()
 
-        label_train_set = stratify.clone()
+        else: 
 
-        unique, counts = np.unique(stratify, return_counts=True) # (GESTURE, ITS WINDOWS)
+            stratify_one_hot = False
+            is_y_one_hot = False
+            NUM_GESTURES = stratify.shape[1]
+            
+            # If labels are one-hot-encoded, convert to 1D array      
+            if stratify.shape[1] != 1:
+                stratify_one_hot = True
+                stratify = np.argmax(stratify, axis=1)
+            if not force_regression and Y_train_set_og.shape[1] != 1:
+                is_y_one_hot = True
+                Y_train_set = np.argmax(Y_train_set_og, axis=1)
+            else:
+                Y_train_set = Y_train_set_og
+
+            label_train_set = stratify.clone()
+
+            unique, counts = np.unique(stratify, return_counts=True) # (GESTURE, ITS WINDOWS)
+
+       
 
         # split data for each class
         X_train = []
@@ -73,13 +90,21 @@ def train_test_split(
 
         for key in class_amount.keys():
             train_size_for_current_class = class_amount[key]
+
             # get indices for current class
-            indices = np.where(stratify == key)[0]
+            if transition_classifier: 
+                key_tensor = torch.tensor(key)
+                indices = torch.all(stratify == key_tensor, dim=1).nonzero(as_tuple=True)[0]
+            else: 
+                indices = np.where(stratify == key)[0]
+            
             indices_train = indices[:train_size_for_current_class]
+
             # get data for current class
             X_train_class = X_train_set[indices_train]
             y_train_class = Y_train_set[indices_train]
             label_train_class = label_train_set[indices_train]
+
             # test set is the rest of the data
             indices_test = np.setdiff1d(indices, indices_train)
             X_test_class = X_train_set[indices_test]
@@ -99,15 +124,20 @@ def train_test_split(
         y_test = np.concatenate(y_test)
         label_train = np.concatenate(label_train)
         label_test = np.concatenate(label_test)
+
+        # If transition classifier and the gestures haven't been transitioned back yet
         
-        # if input labels are one-hot-encoded, output labels are one-hot-encoded
-        if not force_regression and is_y_one_hot:
-            NUM_GESTURES = Y_train_set_og.shape[1] 
-            y_train = np.eye(NUM_GESTURES)[y_train]
-            y_test = np.eye(NUM_GESTURES)[y_test]
-        if stratify_one_hot:
-            label_train = np.eye(NUM_GESTURES)[label_train]
-            label_test = np.eye(NUM_GESTURES)[label_test]
+        
+        if not transition_classifier: 
+        
+            # if input labels are one-hot-encoded, output labels are one-hot-encoded
+            if not force_regression and is_y_one_hot:
+                NUM_GESTURES = Y_train_set_og.shape[1] 
+                y_train = np.eye(NUM_GESTURES)[y_train]
+                y_test = np.eye(NUM_GESTURES)[y_test]
+            if stratify_one_hot:
+                label_train = np.eye(NUM_GESTURES)[label_train]
+                label_test = np.eye(NUM_GESTURES)[label_test]
         
     else: # shuffle=True or stratify=None
         arrays = list(arrays) + [stratify]


### PR DESCRIPTION
Add transition classifier for datasets with transitions: ninapro db2, ninapro db3, ninapro db5, uci, and mcs. 

- Balance such that there is an even limit for transition windows and non transition windows (averaged separately NOT overall, doing so would lead to much less training data). 
- Stratify by type of transitions (all the (start_gesture, end_gesture) windows are equally stratified NOT just stratified by transition and non-transition). 
- Ninapro db3 and db5 had the highest accuracy after two epochs performing at 81% and 66% respectively. Likely due to the fact that this was the only dataset with actual transitions (for mcs and uci we inferred transition periods) and more of them. Other datasets averaged between 36% and 55% accuracy.